### PR TITLE
Added targets relink-and-build and transplant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ help:
 	#   install - installs Poplog into $(POPLOG_HOME) folder as V16
 	#   uninstall - removes Poplog entirely, leaving a backup in /tmp/POPLOG_HOME_DIR.tgz
 	#   really-uninstall-poplog - removes Poplog and does not create a backup.
+	#   relink-and-build - a more complex build process that can relink the 
+	#       corepop executable and is useful for O/S upgrades.
 	#   jumpstart - installs the packages this installation depends on.
 	#   clean - removes all the build artifacts.
 	#   help - this explanation, for more info read the Makefile comments.
@@ -313,3 +315,53 @@ _build/MakeIndexes.proxy: _build/Stage2.proxy _build/Docs.proxy _build/Packages.
 
 _build/Done.proxy: _build/MakeIndexes.proxy _build/PoplogCommander.proxy
 	touch $@
+
+# The transplant target is useful to get the _build folder fully
+# built and then the whole GetPoplog-tree is captured as a tarball.
+# This is used on host X in order to relink on host Y. The process 
+# is as follows:
+#   On host X
+#       make transplant
+#       scp _build/transplant-getpoplog.tgz $hostY:transplant-getpoplog.tgz
+#   On host Y
+#       mkdir Seed
+#       cd Seed
+#       tar zxf ../transplant-getpoplog.tgz
+#       make relink-and-build
+#
+.PHONY: transplant
+transplant: _build/transplant-getpoplog.tgz
+	true
+
+_build/transplant-getpoplog.tgz: _build/Done.proxy
+	TMPFILE=`mktemp` \
+	; echo TMPFILE=$$TMPFILE \
+	; ( tar cf - . | gzip ) > "$$TMPFILE" \
+	; mv "$$TMPFILE" $@
+
+# If no valid corepop image is found in Corepops then the normal 
+# build process will stop. Quite often it is sufficient to relink
+# on the new system and then the process can be restarted. This
+# target assists with that process.
+#
+# Start on a host X on which GetPoplog successfully builds. Copy
+# the whole GetPoplog-tree onto the new host Y. (One way to do that
+# is to use the phony target `transplant`, which leaves
+# its result in _build/transplant-getpoplog.tgz.) 
+# 
+# Once the GetPoplog-tree assives on host Y, use this target 
+# to attempt the relinking of a new Poplog executable on host Y.
+# If this generates a working 'corepop' image then the normal
+# build process is attempted with the new image substituted.
+.PHONY: relink-and-build
+relink-and-build: 
+	[ -f _build/Done.proxy ] # Sanity check that we are starting from a pre-built tree.
+	export usepop=$(abspath ./_build/poplog_base) \
+	&& . ./_build/poplog_base/pop/com/popenv.sh \
+	&& cd $$popsys \
+	&& env PATH="$$popsys:$$PATH" $$usepop/pop/pop/poplink_cmnd
+	output=`./_build/poplog_base/pop/pop/newpop11 ":sysexit()" 2>&1` && [ -z "$$output" ] # Check the rebuilt newpop11 works
+	mv _build/poplog_base/pop/pop/newpop11 .
+	$(MAKE) clean && $(MAKE) _build/Base.proxy
+	mv newpop11 _build/poplog_base/pop/pop/corepop
+	$(MAKE) build


### PR DESCRIPTION
The main strategy for building Poplog on a new host depends on having a working `corepop` binary. However, new versions of Linux can invalidate the available images. To get around this it is usually enough to simply relink the Poplog object files to create a new `corepop` binary.

The idea is to use the Seed Makefile to build a fully working tree on a host where Poplog already works. We will then bundle up the whole folder and transplant it to the new host.  (As a convenience, the phony target `transplant` performs a full build and then tarballs the entire Seed folder into `_build/transplant-getpoplog.tgz`, which can be moved to the new host.)

On the new host, once we have restored the Seed folder from the working system, we run the relink-and-build target:
```sh
make relink-and-build
```
If relinking is all that is needed, this will relink and rebuild on the new host, ready for installation using `make install`.