### PR TITLE
In-line the compile_popvision_linux script to eliminate csh dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ _build/ExtraScripts.proxy: _build/poplog_base/pop/com/poplogout.sh _build/poplog
 _build/Packages.proxy: _build/packages-V16.tar.bz2
 	mkdir -p _build
 	(cd _build/poplog_base/pop; tar jxf ../../packages-V16.tar.bz2)
-	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; ../com/compile_popvision_linux
+	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; for f in *.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	touch $@
 
 _build/Docs.proxy: _build/Base.proxy


### PR DESCRIPTION
The compile_popvision_linux_script uses `/bin/csh` and we're trying to completely remove that dependency. In addition it does not use the `-p` flag on mkdir. We can't fix these issues until we assimilate the FreePoplog packages - and that is scheduled for 2 sprints time. So in the interim it is best to in-line the script into the Makefile.