### PR TITLE
V0.2/prebuilt dir for snap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -565,13 +565,15 @@ buildsnap:
 	$(MAKE) buildsnapcraftready
 	cd _build/dotsnap; snapcraft
 
+PREBUILT_DIR:=/prebuilt
+
 .PHONY: buildsnapcraftready
 buildsnapcraftready: _build/Seed/snapcraft.yaml
 	[ -f _build/poplog.tar.gz ] # Enforce required tarball
-	mkdir -p _build/dotsnap/tmp$(POPLOG_VERSION_DIR)
-	mkdir -p _build/dotsnap/tmp/usr/bin
-	cat _build/poplog.tar.gz | ( cd _build/dotsnap/tmp$(POPLOG_VERSION_DIR); tar zxf - )
-	cd _build/dotsnap/tmp/usr/bin; ln -s ../..$(POPLOG_VERSION_DIR)/pop/pop/poplog .
+	mkdir -p _build/dotsnap$(PREBUILT_DIR)$(POPLOG_VERSION_DIR)
+	mkdir -p _build/dotsnap$(PREBUILT_DIR)/usr/bin
+	cat _build/poplog.tar.gz | ( cd _build/dotsnap/$(PREBUILT_DIR)$(POPLOG_VERSION_DIR); tar zxf - )
+	cd _build/dotsnap$(PREBUILT_DIR)/usr/bin; ln -s ../..$(POPLOG_VERSION_DIR)/pop/pop/poplog .
 	cp _build/Seed/snapcraft.yaml _build/dotsnap	
 
 _build/Seed/snapcraft.yaml:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,4 +35,4 @@ parts:
 
 apps:
   poplog:
-    command: opt/poplog/V16/pop/pop/poplog
+    command: usr/bin/poplog

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,7 +16,7 @@ base: core20
 parts:
   poplog:
     plugin: dump
-    source: tmp/
+    source: prebuilt/
     source-type: local
     build-attributes: [keep-execstack]
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |
   later marketed as a commercial package for software development as well 
   as for teaching and research. It was one of the initiatives supported for 
   a while by the UK government-funded Alvey Programme.
-confinement: devmode
+confinement: classic
 grade: devel
 base: core20
 


### PR DESCRIPTION
This change has several tweaks to the snap build process:

- Confinement is classic rather than devmode
- Grade is beta rather than candidate
- The poplog command is now referenced via symlink
- The folder name is no longer `tmp` but `prebuilt`, following Waldek's concern that `tmp` was asking for trouble.