### PR TITLE
Fix issue with snap build when POPLOG_HOME_DIR is /usr/local/poplog

### DIFF
--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -1,4 +1,4 @@
 #!/bin/sh
 LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH}" 
 export LD_LIBRARY_PATH
-exec ${APPDIR}/opt/poplog/V16/pop/pop/poplog $*
+exec ${APPDIR}/usr/bin/poplog $*

--- a/Makefile
+++ b/Makefile
@@ -550,6 +550,8 @@ buildappimage: _build/Seed/AppDir/AppRun _build/appimagetool
 	# Now to create systematically re-named symlinks.
 	cd _build/AppDir/usr/lib; for i in *.so.*; do ln -s $$i `echo "$$i" | sed 's/\.so\.[^.]*$$/.so/'`; done
 	chmod a-w _build/AppDir/usr/lib/*
+	mkdir -p _build/AppDir/usr/bin
+	cd _build/AppDir/usr/bin; ln -s ../..$(POPLOG_VERSION_DIR)/pop/pop/poplog .
 	cd _build && ARCH=x86_64 ./appimagetool AppDir
 
 _build/appimagetool:


### PR DESCRIPTION
The path was hard coded into AppDir. The fix is to hard-code a symlink (/usr/bin/poplog) and create that link when building.