### PR TITLE
V0.2/add prefix variable to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,10 @@
 #         place.
 #
 
-# The PREFIX variable is used to set up POPLOG_HOME_DIR (and nowhere else, 
-# please). It is provided in order to fit in with the conventions of Makefiles. 
-PREFIX:=/usr/local/poplog
+# The PREFIX variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
+# nowhere else, please). It is provided in order to fit in with the conventions 
+# of Makefiles. 
+PREFIX:=/usr/local
 
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:
@@ -82,7 +83,7 @@ PREFIX:=/usr/local/poplog
 #   POPLOCAL_HOME_DIR           /opt/poplog				$poplocal = $usepop/..
 #   POPLOCAL_VERSION_DIR        /opt/poplog/L16			
 #   POPLOCAL_VERSION_SYMLINK    /opt/poplog/local -> /opt/poplog/L16
-POPLOG_HOME_DIR:=$(PREFIX)
+POPLOG_HOME_DIR:=$(PREFIX)/poplog
 MAJOR_VERSION:=16
 MINOR_VERSION:=1
 FULL_VERSION:=$(MAJOR_VERSION).$(MINOR_VERSION)
@@ -96,7 +97,7 @@ POPLOCAL_VERSION_DIR:=$(POPLOCAL_HOME_DIR)/$(VERSION_DIR)
 POPLOCAL_VERSION_SYMLINK:=$(POPLOCAL_HOME_DIR)/$(SYMLINK)
 
 # This is the folder where the link to the poplog-shell executable will be installed.
-EXEC_DIR:=/usr/local/bin
+EXEC_DIR:=$(PREFIX)/bin
 
 # Allow overriding of the branches used for the different repositories.
 DEFAULT_BRANCH:=main

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,21 @@
 #         place.
 #
 
+# The PREFIX variable is used to set up POPLOG_HOME_DIR (and nowhere else, 
+# please). It is provided in order to fit in with the conventions of Makefiles. 
+PREFIX:=/usr/local/poplog
+
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:
 #     make install POPLOG_HOME_DIR=/opt/poplog
 # Resulting values would be:
-#	POPLOG_HOME_DIR 			/opt/poplog
-#	POPLOG_VERSION_DIR			/opt/poplog/V16
+#	POPLOG_HOME_DIR 			/opt/poplog        		$usepop/..
+#	POPLOG_VERSION_DIR			/opt/poplog/V16			$usepop
 #	POPLOG_VERSION_SYMLINK		/opt/poplog/current_usepop -> /opt/poplog/V16
-POPLOG_HOME_DIR:=/usr/local/poplog
+#   POPLOCAL_HOME_DIR           /opt/poplog				$poplocal = $usepop/..
+#   POPLOCAL_VERSION_DIR        /opt/poplog/L16			
+#   POPLOCAL_VERSION_SYMLINK    /opt/poplog/local -> /opt/poplog/L16
+POPLOG_HOME_DIR:=$(PREFIX)
 MAJOR_VERSION:=16
 MINOR_VERSION:=1
 FULL_VERSION:=$(MAJOR_VERSION).$(MINOR_VERSION)
@@ -83,6 +90,10 @@ VERSION_DIR:=V$(MAJOR_VERSION)
 POPLOG_VERSION_DIR:=$(POPLOG_HOME_DIR)/$(VERSION_DIR)
 SYMLINK:=current_usepop
 POPLOG_VERSION_SYMLINK:=$(POPLOG_HOME_DIR)/$(SYMLINK)
+
+POPLOCAL_HOME_DIR:=$(POPLOG_HOME_DIR)
+POPLOCAL_VERSION_DIR:=$(POPLOCAL_HOME_DIR)/$(VERSION_DIR)
+POPLOCAL_VERSION_SYMLINK:=$(POPLOCAL_HOME_DIR)/$(SYMLINK)
 
 # This is the folder where the link to the poplog-shell executable will be installed.
 EXEC_DIR:=/usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@
 # The PREFIX variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
 # nowhere else, please). It is provided in order to fit in with the conventions 
 # of Makefiles. 
-DESTDIR?=/
-PREFIX?=$(DESTDIR)usr/local
+DESTDIR?=
+PREFIX?=$(DESTDIR)/usr/local
 
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@
 # The PREFIX variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
 # nowhere else, please). It is provided in order to fit in with the conventions 
 # of Makefiles. 
-PREFIX:=/usr/local
+DESTDIR?=/
+PREFIX?=$(DESTDIR)usr/local
 
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:


### PR DESCRIPTION
Bring the Seed Makefile more into line with best practice by introducing `DESTDIR` and `PREFIX` variables. Guidelines are:

From https://stackoverflow.com/questions/50603956/destdir-vs-prefix-options-in-a-build-system
> The prefix is intended to be the location where the package will be installed (or appear to be installed) after everything is finalized. For example, if there are hardcoded paths in the package anywhere they would be based on the prefix path (of course, we all hope packages avoid hardcoded paths for many reasons).
DESTDIR allows people to actually install the content somewhere other than the actual prefix: the DESTDIR is prepended to all prefix values so that the install location has exactly the same directory structure/layout as the final location, but rooted somewhere other than /.