### PR TITLE
V0.2/new target use repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,10 @@
 #         place.
 #
 
-# The PREFIX variable is used to set up POPLOG_HOME_DIR (and nowhere else, 
-# please). It is provided in order to fit in with the conventions of Makefiles. 
-PREFIX:=/usr/local/poplog
+# The PREFIX variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
+# nowhere else, please). It is provided in order to fit in with the conventions 
+# of Makefiles. 
+PREFIX:=/usr/local
 
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:
@@ -82,7 +83,7 @@ PREFIX:=/usr/local/poplog
 #   POPLOCAL_HOME_DIR           /opt/poplog				$poplocal = $usepop/..
 #   POPLOCAL_VERSION_DIR        /opt/poplog/L16			
 #   POPLOCAL_VERSION_SYMLINK    /opt/poplog/local -> /opt/poplog/L16
-POPLOG_HOME_DIR:=$(PREFIX)
+POPLOG_HOME_DIR:=$(PREFIX)/poplog
 MAJOR_VERSION:=16
 MINOR_VERSION:=1
 FULL_VERSION:=$(MAJOR_VERSION).$(MINOR_VERSION)
@@ -96,7 +97,7 @@ POPLOCAL_VERSION_DIR:=$(POPLOCAL_HOME_DIR)/$(VERSION_DIR)
 POPLOCAL_VERSION_SYMLINK:=$(POPLOCAL_HOME_DIR)/$(SYMLINK)
 
 # This is the folder where the link to the poplog-shell executable will be installed.
-EXEC_DIR:=/usr/local/bin
+EXEC_DIR:=$(PREFIX)/bin
 
 # Allow overriding of the branches used for the different repositories.
 DEFAULT_BRANCH:=main

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,21 @@
 #         place.
 #
 
+# The PREFIX variable is used to set up POPLOG_HOME_DIR (and nowhere else, 
+# please). It is provided in order to fit in with the conventions of Makefiles. 
+PREFIX:=/usr/local/poplog
+
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:
 #     make install POPLOG_HOME_DIR=/opt/poplog
 # Resulting values would be:
-#	POPLOG_HOME_DIR 			/opt/poplog
-#	POPLOG_VERSION_DIR			/opt/poplog/V16
+#	POPLOG_HOME_DIR 			/opt/poplog        		$usepop/..
+#	POPLOG_VERSION_DIR			/opt/poplog/V16			$usepop
 #	POPLOG_VERSION_SYMLINK		/opt/poplog/current_usepop -> /opt/poplog/V16
-POPLOG_HOME_DIR:=/usr/local/poplog
+#   POPLOCAL_HOME_DIR           /opt/poplog				$poplocal = $usepop/..
+#   POPLOCAL_VERSION_DIR        /opt/poplog/L16			
+#   POPLOCAL_VERSION_SYMLINK    /opt/poplog/local -> /opt/poplog/L16
+POPLOG_HOME_DIR:=$(PREFIX)
 MAJOR_VERSION:=16
 MINOR_VERSION:=1
 FULL_VERSION:=$(MAJOR_VERSION).$(MINOR_VERSION)
@@ -83,6 +90,10 @@ VERSION_DIR:=V$(MAJOR_VERSION)
 POPLOG_VERSION_DIR:=$(POPLOG_HOME_DIR)/$(VERSION_DIR)
 SYMLINK:=current_usepop
 POPLOG_VERSION_SYMLINK:=$(POPLOG_HOME_DIR)/$(SYMLINK)
+
+POPLOCAL_HOME_DIR:=$(POPLOG_HOME_DIR)
+POPLOCAL_VERSION_DIR:=$(POPLOCAL_HOME_DIR)/$(VERSION_DIR)
+POPLOCAL_VERSION_SYMLINK:=$(POPLOCAL_HOME_DIR)/$(SYMLINK)
 
 # This is the folder where the link to the poplog-shell executable will be installed.
 EXEC_DIR:=/usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@
 # The PREFIX variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
 # nowhere else, please). It is provided in order to fit in with the conventions 
 # of Makefiles. 
-DESTDIR?=/
-PREFIX?=$(DESTDIR)usr/local
+DESTDIR?=
+PREFIX?=$(DESTDIR)/usr/local
 
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@
 # The PREFIX variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
 # nowhere else, please). It is provided in order to fit in with the conventions 
 # of Makefiles. 
-PREFIX:=/usr/local
+DESTDIR?=/
+PREFIX?=$(DESTDIR)usr/local
 
 # This is the folder in which the new Poplog build will be installed. To install Poplog 
 # somewhere different, such as /opt/poplog either edit this line or try:

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,8 @@ help:
 	#   install [^] - installs Poplog into $(POPLOG_HOME) folder as V16.
 	#   uninstall [^] - removes Poplog entirely, leaving a backup in /tmp/POPLOG_HOME_DIR.tgz.
 	#   really-uninstall-poplog [^] - removes Poplog and does not create a backup.
+	#   use-repos - tells the build script to assume that the sister repos have
+	#       been cloned/downloaded and that there is no need to download them.
 	#   relink-and-build - a more complex build process that can relink the 
 	#       corepop executable and is useful for O/S upgrades.
 	#   jumpstart-ubuntu [^] - installs the packages a Ubuntu system needs.
@@ -282,6 +284,20 @@ jumpstart-opensuse-leap:
 
 .PHONY: download
 download: _build/Docs.Downloaded.proxy _build/Base.Downloaded.proxy _build/Corepops.Downloaded.proxy _build/Seed.Downloaded.proxy _build/Packages.Downloaded.proxy
+
+# Instructs the build process to assume that the sister github repos have been
+# cloned and/or downloaded and reside in ../Base, ../Docs etc. This does not
+# include Aaron Sloman's packages at this time. Also the normal procedure
+# for getting the Seed file neatly copes with it being a git repo already.
+.PHONY: use-repos
+use-repos: _build/Seed.Downloaded.proxy _build/Packages.Downloaded.proxy
+	mkdir -p _build/Corepops
+	( cd ../Corepops; tar cf - . ) | ( cd _build/Corepops; tar xf - )
+	mkdir -p _build/Base
+	( cd ../Base; tar cf - . ) | ( cd _build/Base; tar xf - )
+	mkdir -p _build/Docs
+	( cd ../Docs; tar cf - . ) | ( cd _build/Docs; tar xf - )
+	touch _build/Docs.Downloaded.proxy _build/Base.Downloaded.proxy _build/Corepops.Downloaded.proxy 
 
 # It is not clear that these scripts should be included or not. If they are it makes
 # more sense to include them in the Base repo. TODO: TO BE CONFIRMED - until then these


### PR DESCRIPTION
Add a new target to support the scenario where the repos have already been cloned locally. In this case we can reduce the downloading during build. The only remaining download activity is for pulling Aaron Sloman's packages tarball. This allows package creators to do this:
```sh
git clone https://github.com/GetPoplog/Seed
git clone https://github.com/GetPoplog/Base
git clone https://github.com/GetPoplog/Corepops
git clone https://github.com/GetPoplog/Docs
( cd Seed; make use-repos && make build )
```