### PR TITLE
V0.2/support scripts

### DIFF
--- a/GetPoplog.sh
+++ b/GetPoplog.sh
@@ -3,15 +3,18 @@
 # Limited to working on the main branch.
 set -e
 
+SEED_BRANCH=main
+SEED_TARBALL_URL=https://github.com/GetPoplog/Seed/archive/${SEED_BRANCH}.tar.gz
+
 # Get minimum dependencies.
 sudo apt update && sudo apt install -y make curl
 
 # Retrieve our Makefile in a temporary directory
 TMP_DIR=`mktemp -d -t ci-XXXXXXXXXX`
 mkdir -p $TMP_DIR
-cd $TMPDIR
+cd $TMP_DIR
 echo "Using temporary directory $TMP_DIR as a build folder"
-curl -LsS https://raw.githubusercontent.com/GetPoplog/Seed/main/Makefile > Makefile
+curl -LsS ${SEED_TARBALL_URL} | tar zxf - --strip-components=1
 
 sudo make jumpstart-ubuntu    # fetch dependencies (Debian based systems only)
 make build

--- a/makeSystemTools.sh
+++ b/makeSystemTools.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-SEED_DIR=`pwd`
+SEED_DIR=`pwd`/_build/Seed
 
 # Run the initialisation files to set up additional environment
 # variables.

--- a/makeSystemTools.sh
+++ b/makeSystemTools.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-SEED_DIR=`pwd`/_build/Seed
+SEED_DIR=`pwd`
 
 # Run the initialisation files to set up additional environment
 # variables.


### PR DESCRIPTION
This change removes support for the "Lone Star" Makefile pre-build scenario. That use-case complicates everything and brings no benefit that we can't get a different, simpler way if we need it.