### PR TITLE
New default for $poplocal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,6 @@ PREFIX?=$(DESTDIR)/usr/local
 #	POPLOG_VERSION_DIR			/opt/poplog/V16			$usepop
 #	POPLOG_VERSION_SYMLINK		/opt/poplog/current_usepop -> /opt/poplog/V16
 #   POPLOCAL_HOME_DIR           /opt/poplog				$poplocal = $usepop/..
-#   POPLOCAL_VERSION_DIR        /opt/poplog/L16			
-#   POPLOCAL_VERSION_SYMLINK    /opt/poplog/local -> /opt/poplog/L16
 POPLOG_HOME_DIR:=$(PREFIX)/poplog
 MAJOR_VERSION:=16
 MINOR_VERSION:=1
@@ -96,7 +94,7 @@ POPLOG_VERSION_DIR:=$(POPLOG_HOME_DIR)/$(VERSION_DIR)
 SYMLINK:=current_usepop
 POPLOG_VERSION_SYMLINK:=$(POPLOG_HOME_DIR)/$(SYMLINK)
 
-POPLOCAL_HOME_DIR:=$(PREFIX)/poplocal
+POPLOCAL_HOME_DIR:=$(POPLOG_VERSION_DIR)/../../poplocal
 
 # This is the folder where the link to the poplog-shell executable will be installed.
 EXEC_DIR:=$(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,7 @@ POPLOG_VERSION_DIR:=$(POPLOG_HOME_DIR)/$(VERSION_DIR)
 SYMLINK:=current_usepop
 POPLOG_VERSION_SYMLINK:=$(POPLOG_HOME_DIR)/$(SYMLINK)
 
-POPLOCAL_HOME_DIR:=$(POPLOG_HOME_DIR)
-POPLOCAL_VERSION_DIR:=$(POPLOCAL_HOME_DIR)/$(VERSION_DIR)
-POPLOCAL_VERSION_SYMLINK:=$(POPLOCAL_HOME_DIR)/$(SYMLINK)
+POPLOCAL_HOME_DIR:=$(PREFIX)/poplocal
 
 # This is the folder where the link to the poplog-shell executable will be installed.
 EXEC_DIR:=$(PREFIX)/bin
@@ -140,6 +138,7 @@ help:
 	#   download - downloads all the archives required by the build process.
 	#   build - creates a complete build-tree in _build/poplog_base.
 	#   install [^] - installs Poplog into $(POPLOG_HOME) folder as V16.
+	#	install-poplocal - installs a 'skeleton' folder for $$poplocal. Optional.
 	#   uninstall [^] - removes Poplog entirely, leaving a backup in /tmp/POPLOG_HOME_DIR.tgz.
 	#   systests - runs self-checks on an installed Poplog system
 	#   really-uninstall-poplog [^] - removes Poplog and does not create a backup.
@@ -206,6 +205,14 @@ install:
 	mkdir -p $(EXEC_DIR)
 	ln -sf $(POPLOG_VERSION_SYMLINK)/pop/pop/poplog $(EXEC_DIR)/
 	# Target "install" completed
+
+.PHONY: install-poplocal
+install-poplocal:
+	mkdir -p $(POPLOCAL_HOME_DIR)
+	( cd poplocal; tar cf - --exclude=.gitkeep . ) | ( cd $(POPLOCAL_HOME_DIR); tar xf - . )
+	# Target "install-poplocal" completed.
+
+
 
 # No messing around - this is not a version change (we don't have a target for that)
 # but a complete removal of all installed Poplogs. This is potentially disasterous, 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ help:
 	#   download - downloads all the archives required by the build process.
 	#   build - creates a complete build-tree in _build/poplog_base.
 	#   install [^] - installs Poplog into $(POPLOG_HOME) folder as V16.
-	#	install-poplocal - installs a 'skeleton' folder for $$poplocal. Optional.
+	#   install-poplocal - installs a 'skeleton' folder for $$poplocal. Optional.
 	#   uninstall [^] - removes Poplog entirely, leaving a backup in /tmp/POPLOG_HOME_DIR.tgz.
 	#   systests - runs self-checks on an installed Poplog system
 	#   really-uninstall-poplog [^] - removes Poplog and does not create a backup.

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -360,6 +360,8 @@ static_assert( false, "Not defined for operating systems other than Darwin nor L
 cat << \****
 
 #define USEPOP_LITERAL "[//USEPOP//]"
+
+// Compile-time string concatenation using literals saves tedious string coding.
 #define POPLOCAL_LITERAL USEPOP_LITERAL "/../../poplocal"
 
 const char * const USEPOP = USEPOP_LITERAL;

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -359,7 +359,10 @@ static_assert( false, "Not defined for operating systems other than Darwin nor L
 
 cat << \****
 
-const char * const USEPOP = "[//USEPOP//]";
+#define USEPOP_LITERAL "[//USEPOP//]"
+#define POPLOCAL_LITERAL USEPOP_LITERAL "/../../poplocal"
+
+const char * const USEPOP = USEPOP_LITERAL;
 
 void truncatePopCom( char * base ) {
     const char * const required_suffix = "/pop/pop";
@@ -455,13 +458,13 @@ echo
 ################################################################################
 
 CODE1=`env -i sh -c '(usepop="_build/poplog_base" && . $usepop/pop/com/popenv.sh && env)' | sort \
-| grep -v '^\(_\|SHLVL\|PWD\|poplib\)=' \
+| grep -v '^\(_\|SHLVL\|PWD\|poplib\|poplocal\(auto\|bin\)\?\)=' \
 | sed -e 's!_build/poplog_base![//USEPOP//]!g' \
 | sed -e 's/"/\\"/g' \
 | sed -e 's/\([^=]*\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'`
 
 CODE2=`env -i sh -c '(usepop="_build/poplog_base/pop/.." && . $usepop/pop/com/popenv.sh && env)' | sort \
-| grep -v '^\(_\|SHLVL\|PWD\|poplib\)=' \
+| grep -v '^\(_\|SHLVL\|PWD\|poplib\|poplocal\(auto\|bin\)\?\)=' \
 | sed -e 's!_build/poplog_base/pop/..![//USEPOP//]!g' \
 | sed -e 's/"/\\"/g' \
 | sed -e 's/\([^=]*\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'`
@@ -472,6 +475,16 @@ fi
 
 echo "$CODE1"
 echo 
+
+################################################################################
+# Note that poplocal needs special handling. 
+################################################################################
+
+cat << \****
+    setEnvReplacingUSEPOP( "poplocal", POPLOCAL_LITERAL, base, inherit_env );
+    setEnvReplacingUSEPOP( "poplocalauto", POPLOCAL_LITERAL "/auto", base, inherit_env );
+    setEnvReplacingUSEPOP( "poplocalbin", POPLOCAL_LITERAL "/psv", base, inherit_env );
+****
 
 ################################################################################
 # Note that poplib needs special handling. The algorithm used in $popcom/popenv.sh

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -477,7 +477,11 @@ echo "$CODE1"
 echo 
 
 ################################################################################
-# Note that poplocal needs special handling. 
+# Note that $poplocal needs special handling. The pre-existing defaults are
+# problematic because they can leave $poplocal pointing to a read-only area.
+# However, changing $poplocal's default also requires handling the dependent 
+# variables $poplocalauto and $poplocalbin. See discussion here:
+# https://github.com/GetPoplog/Seed/wiki/A-new-default-for-$poplocal
 ################################################################################
 
 cat << \****


### PR DESCRIPTION
Following the reflections on [the right default value of `$poplocal`](https://github.com/GetPoplog/Seed/wiki/A-new-default-for-$poplocal), here is a pull request to implement that new value. It has two parts:

  - Ensuring that $poplocal, $poplocalauto and $poplocalbin are consistently set with the new default if `$usepop/../../poplocal`
  - Adding a target for creating a $poplocal Poplog-tree. 