### PR TITLE
Configure CircleCI to push releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,15 @@ jobs:
       - run:
           command: |
             make builddeb POPLOG_HOME_DIR=/opt/poplog
+            mkdir -p _build/artifacts
+            mv _build/poplog_16.1-1_amd64.deb _build/artifacts/
       - store_artifacts:
-          path: _build/poplog_16.1-1_amd64.deb
+          path: _build/artifacts/poplog_16.1-1_amd64.deb
           destination: poplog_16.1-1_amd64.deb
       - persist_to_workspace:
           root: _build
           paths:
-            - poplog_16.1-1_amd64.deb
+            - artifacts/poplog_16.1-1_amd64.deb
   test_deb:
     machine:
       image: ubuntu-2004:202104-01
@@ -90,11 +92,12 @@ jobs:
             sudo apt install -y python3 python3-pip
             pip3 install nose2
       - attach_workspace:
-          at: _workspace
+          at: ./_build
       - run:
           name: Install Poplog from *.deb file
           command: |
-            sudo apt install ./_workspace/poplog_16.1-1_amd64.deb
+            sudo apt install ./_build/artifacts/poplog_16.1-1_amd64.deb
+
       - run:
           name: Run systests
           command: |
@@ -144,12 +147,18 @@ jobs:
             sudo apt update
             sudo apt install -y make curl libncurses5 libncurses5-dev
       - run:
-          command:
+          command: |
             make buildappimage POPLOG_HOME_DIR=/opt/poplog
+            mkdir -p _build/artifacts
+            mv _build/Poplog-x86_64.AppImage _build/artifacts/
       - store_artifacts:
-          path: _build/Poplog-x86_64.AppImage
+          path: _build/artifacts/Poplog-x86_64.AppImage
           destination: Poplog-x86_64.AppImage
-  build_snap_using_container:
+      - persist_to_workspace:
+          root: _build
+          paths:
+            - artifacts/Poplog-x86_64.AppImage
+  build_snap:
     docker:
       - image: cibuilds/snapcraft:core20
     steps:
@@ -171,29 +180,77 @@ jobs:
       - run:
           command: |
             make buildsnapcraftready POPLOG_HOME_DIR=/opt/poplog
-            cd _build/dotsnap; snapcraft
+            pushd _build/dotsnap; snapcraft; popd
+            mkdir -p _build/artifacts
+            mv _build/dotsnap/poplog_16.0.1_amd64.snap _build/artifacts/
       - store_artifacts:
-          path: _build/dotsnap/poplog_16.0.1_amd64.snap
+          path: _build/artifacts/poplog_16.0.1_amd64.snap
           destination: poplog_16.0.1_amd64.snap
+      - persist_to_workspace:
+          root: _build
+          paths:
+            - artifacts/poplog_16.0.1_amd64.snap
+  publish_github_release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: ./_build
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete "${CIRCLE_TAG}" ./_build/artifacts/
 
 workflows:
   version: 2
   mainflow:
     jobs:
-      - one_line_install
-      - build_tree
+      - one_line_install:
+          filters:  # required since `publish-github-release` has tag filters AND depends on this
+            tags:
+              only: /.*/
+      - build_tree:
+          filters:  # required since `publish-github-release` has tag filters AND depends on this
+            tags:
+              only: /.*/
       - build_deb:
           requires:
             - build_tree
+          filters:  # required since `publish-github-release` has tag filters AND depends on this
+            tags:
+              only: /.*/
       - build_rpm:
           requires:
             - build_tree
+          filters:  # required since `publish-github-release` has tag filters AND depends on this
+            tags:
+              only: /.*/
       - build_appimage:
           requires:
             - build_tree
-      - build_snap_using_container:
+          filters:  # required since `publish-github-release` has tag filters AND depends on this
+            tags:
+              only: /.*/
+      - build_snap:
           requires:
             - build_tree
+          filters:  # required since `publish-github-release` has tag filters AND depends on this
+            tags:
+              only: /.*/
       - test_deb:
           requires:
             - build_deb
+          filters:  # required since `publish-github-release` has tag filters AND depends on this
+            tags:
+              only: /.*/
+      - publish_github_release:
+          requires:
+            - test_deb
+            - build_appimage
+            - build_snap
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+.*$/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,48 +201,39 @@ jobs:
           command: |
             ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete "${CIRCLE_TAG}" ./_build/artifacts/
 
+default_filters: &default_filters
+  # required to run on tagged releases.
+  tags:
+    only: /.*/
+
 workflows:
   version: 2
   mainflow:
     jobs:
       - one_line_install:
-          filters:  # required since `publish-github-release` has tag filters AND depends on this
-            tags:
-              only: /.*/
+          filters:  *default_filters
       - build_tree:
-          filters:  # required since `publish-github-release` has tag filters AND depends on this
-            tags:
-              only: /.*/
+          filters:  *default_filters
       - build_deb:
           requires:
             - build_tree
-          filters:  # required since `publish-github-release` has tag filters AND depends on this
-            tags:
-              only: /.*/
+          filters:  *default_filters
       - build_rpm:
           requires:
             - build_tree
-          filters:  # required since `publish-github-release` has tag filters AND depends on this
-            tags:
-              only: /.*/
+          filters:  *default_filters
       - build_appimage:
           requires:
             - build_tree
-          filters:  # required since `publish-github-release` has tag filters AND depends on this
-            tags:
-              only: /.*/
+          filters:  *default_filters
       - build_snap:
           requires:
             - build_tree
-          filters:  # required since `publish-github-release` has tag filters AND depends on this
-            tags:
-              only: /.*/
+          filters:  *default_filters
       - test_deb:
           requires:
             - build_deb
-          filters:  # required since `publish-github-release` has tag filters AND depends on this
-            tags:
-              only: /.*/
+          filters:  *default_filters
       - publish_github_release:
           requires:
             - test_deb


### PR DESCRIPTION
This uses ghr to persist all built binaries (snap, AppImage, and deb) to
github releases only on tagged commits.