### PR TITLE
Build on Ubuntu 16.04 test on both 16.04 and 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2.1
 jobs:
   one_line_install:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-1604:202104-01
     steps:
       - run:
           command: |
             curl -LsS https://raw.githubusercontent.com/GetPoplog/Seed/main/GetPoplog.sh | sh
   build_tree:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-1604:202104-01
     steps:
       - checkout
       - run:
@@ -77,7 +77,7 @@ jobs:
             - artifacts/poplog_16.1-1_amd64.deb
   test_deb:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-1604:202104-01
     steps:
       - checkout
       - run:
@@ -132,7 +132,7 @@ jobs:
                 destination: poplog-16.1-1.x86_64.rpm
   build_appimage:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-1604:202104-01
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,13 @@ jobs:
           name: Install Poplog from *.deb file
           command: |
             sudo apt install ./_build/artifacts/poplog_16.1-1_amd64.deb
+      - run:
+          name: Run systests
+          command: |
+            cd systests
+            nose2 -X
+      - store_test_results:
+          path: systests
 
   test_deb_2004:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
     machine:
       image: ubuntu-2004:202104-01
     steps: *systests_steps
-    
+
   build_rpm:
     docker:
       - image: cimg/base:2021.04
@@ -238,7 +238,8 @@ workflows:
           filters:  *default_filters
       - publish_github_release:
           requires:
-            - test_deb
+            - test_deb_1604
+            - test_deb_2004
             - build_appimage
             - build_snap
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,10 @@ jobs:
           root: _build
           paths:
             - artifacts/poplog_16.1-1_amd64.deb
-  test_deb:
+  test_deb_1604:
     machine:
       image: ubuntu-1604:202104-01
-    steps:
+    steps: &systests_steps
       - checkout
       - run:
           name: Get system info
@@ -98,13 +98,11 @@ jobs:
           command: |
             sudo apt install ./_build/artifacts/poplog_16.1-1_amd64.deb
 
-      - run:
-          name: Run systests
-          command: |
-            cd systests
-            nose2 -X
-      - store_test_results:
-          path: systests
+  test_deb_2004:
+    machine:
+      image: ubuntu-2004:202104-01
+    steps: *systests_steps
+    
   build_rpm:
     docker:
       - image: cimg/base:2021.04
@@ -230,7 +228,11 @@ workflows:
           requires:
             - build_tree
           filters:  *default_filters
-      - test_deb:
+      - test_deb_1604:
+          requires:
+            - build_deb
+          filters:  *default_filters
+      - test_deb_2004:
           requires:
             - build_deb
           filters:  *default_filters


### PR DESCRIPTION
Following Michael's report that building on 20.04 leads to a *.deb that installs a non-working system, I have adjusted the builds to run off Ubuntu 16.04 and then tested on 16.04 and 20.04.