### PR TITLE
Fix build on Rocky Linux. (fixes #57)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ help:
 	#       corepop executable and is useful for O/S upgrades.
 	#   jumpstart-ubuntu [^] - installs the packages a Ubuntu system needs.
 	#   jumpstart-fedora [^] - installs the packages a Fedora system needs.
+	#   jumpstart-rocky [^] - installs the packages a Rocky Linux system needs.
 	#   jumpstart-* [^] - and more, try `make help-jumpstart`.
 	#   clean - removes all the build artifacts.
 	#   help - this explanation, for more info read the Makefile comments.
@@ -158,6 +159,7 @@ help-jumpstart:
 	#   jumpstart-debian - installs the packages a Debian system needs
 	#   jumpstart-ubuntu - installs the packages an Ubuntu system needs
 	#   jumpstart-fedora - installs the packages a Fedora system needs.
+	#   jumpstart-rocky - installs the packages a Rocky Linux system needs.
 	#   jumpstart-opensuse-leap - installs the packages a openSUSE Leap system needs.
 	#
 
@@ -289,6 +291,13 @@ jumpstart-fedora:
 	curl make bzip2 \
 	gcc glibc-devel ncurses-devel libXext-devel libX11-devel \
 	libXt-devel openmotif-devel xterm espeak csh
+
+.PHONY: jumpstart-rocky
+jumpstart-rocky:
+	dnf install \
+	curl make bzip2 \
+	gcc glibc-devel ncurses-devel libXext-devel libX11-devel \
+	libXt-devel openmotif-devel xterm csh ncurses-compat-libs
 
 .PHONY: jumpstart-opensuse-leap
 jumpstart-opensuse-leap:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@
 
 # CONVENTION: If we want to allow the user of the Makefile to set via the CLI 
 # then we use ?= to bind it. If it's an internal variables then we use :=
+CC?=gcc
+CFLAGS?=-Wall -std=c99
 
 # The PREFIX variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
 # nowhere else, please). It is provided in order to fit in with the conventions 
@@ -319,7 +321,7 @@ _build/ExtraScripts.proxy: _build/poplog_base/pop/com/poplogout.sh _build/poplog
 _build/Packages.proxy: _build/packages-V16.tar.bz2
 	mkdir -p _build
 	(cd _build/poplog_base/pop; tar jxf ../../packages-V16.tar.bz2)
-	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; for f in *.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
+	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; for f in *.c; do $(CC) $(CFLAGS) -O3 -fpic -shared -o bin/linux/`basename $$f .c`.so $$f; done
 	touch $@
 
 _build/Packages.Downloaded.proxy: _build/packages-V16.tar.bz2
@@ -390,7 +392,7 @@ _build/packages-V16.tar.bz2:
 _build/PoplogCommander.proxy: _build/Stage2.proxy
 	mkdir -p _build/cmdr
 	GET_POPLOG_VERSION=`cat VERSION` sh makePoplogCommander.sh > _build/cmdr/poplog.c
-	( cd _build/cmdr && gcc -Wall -o poplog poplog.c )
+	( cd _build/cmdr && $(CC) $(CFLAGS) -o poplog poplog.c )
 	rm -f _build/poplog_base/pop/pop/poplog
 	cp _build/cmdr/poplog _build/poplog_base/pop/pop/
 	touch $@

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -18,6 +18,15 @@ cat << \****
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdarg.h>
+#include <limits.h>
+
+// POSIX doesn't guarantee that <limits.h> will provide PATH_MAX if there
+// aren't limits imposed by the OS.  In this case, the recommended approach is
+// to use pathconf(3) with _PC_PATH_MAX to get the max limit but this is
+// overkill.
+#ifndef PATH_MAX
+#define PATH_MAX            512  // 256 is the minimum required by POSIX.
+#endif
 
 //  Bit-flags.
 #define RUN_INIT_P          1


### PR DESCRIPTION
Originally the build of the poplog commander failed due to the lack of -std=c99 and the lack of visibility of PATH_MAX.