### PR TITLE
Fix poplog exectuable to no longer segfault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@
 # CONVENTION: If we want to allow the user of the Makefile to set via the CLI 
 # then we use ?= to bind it. If it's an internal variables then we use :=
 CC?=gcc
-CFLAGS?=-Wall -std=c99
+CFLAGS?=-g -Wall -std=c18 -D_POSIX_C_SOURCE=200809L
 
 # The prefix variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
 # nowhere else, please). It is provided in order to fit in with the conventions 
@@ -401,7 +401,7 @@ _build/packages-V16.tar.bz2:
 _build/PoplogCommander.proxy: _build/Stage2.proxy
 	mkdir -p _build/cmdr
 	GET_POPLOG_VERSION=`cat VERSION` sh makePoplogCommander.sh > _build/cmdr/poplog.c
-	( cd _build/cmdr && $(CC) $(CFLAGS) -o poplog poplog.c )
+	( cd _build/cmdr && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
 	rm -f _build/poplog_base/pop/pop/poplog
 	cp _build/cmdr/poplog _build/poplog_base/pop/pop/
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@
 # CONVENTION: If we want to allow the user of the Makefile to set via the CLI 
 # then we use ?= to bind it. If it's an internal variables then we use :=
 CC?=gcc
-CFLAGS?=-g -Wall -std=c18 -D_POSIX_C_SOURCE=200809L
+CFLAGS?=-g -Wall -std=c11 -D_POSIX_C_SOURCE=200809L
 
 # The prefix variable is used to set up POPLOG_HOME_DIR and EXEC_DIR (and 
 # nowhere else, please). It is provided in order to fit in with the conventions 

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -355,6 +355,14 @@ char * selfHome() {
     	return NULL;
     }
 }
+void * safe_malloc( size_t n ) {
+    void * ptr = malloc( n );
+    if ( ptr == NULL ) {
+        perror( NULL );
+        exit( EXIT_FAILURE );
+    }
+    return ptr;
+}
 
 void setEnvSpec( const char * envspec) {
     // envspec is a string of the form "name=val"
@@ -365,20 +373,12 @@ void setEnvSpec( const char * envspec) {
     };
 
     size_t namelen = equalpos - envspec;
-    char * name = malloc( namelen + 1 );
-    if ( name == NULL ) {
-        fprintf( stderr, "Malloc failed\n" );
-        exit( EXIT_FAILURE );
-    }
+    char * name = safe_malloc( namelen + 1 );
     strncpy( name, envspec, namelen );
     name[namelen] = '\0';
 
     int vallen = strlen( envspec ) - ( namelen );
-    char * val = malloc( vallen + 1 );
-    if ( val == NULL ) {
-        fprintf( stderr, "Malloc failed\n" );
-        exit( EXIT_FAILURE );
-    }
+    char * val = safe_malloc( vallen + 1 );
     strncpy( val, equalpos + 1, vallen );
     val[vallen] = '\0';
 
@@ -437,11 +437,7 @@ int howManyTimes( const char * haystack, const char * needle ) {
 void setEnvReplacingUSEPOP( char * name, char * value, char * base, bool inherit_env ) {
     int count = howManyTimes( value, USEPOP );
     size_t len_needed = strlen( value ) + strlen( base ) * count + 1;
-    char * rhs = malloc( len_needed );
-    if ( rhs == NULL ) {
-        fprintf( stderr, "Malloc failed\n" );
-        exit( EXIT_FAILURE );
-    }
+    char * rhs = safe_malloc( len_needed );
     rhs[ 0 ] = '\0';    //  Initialise as empty
 
     char * end_of_rhs = rhs;
@@ -465,11 +461,7 @@ void extendPath( char * prefix, char * path, char * suffix ) {
         exit( EXIT_FAILURE );
     }
 
-    char * buff = malloc( strlen( prefix ) + 1 + strlen( path ) + 1 + strlen( suffix ) + 1 );
-    if ( buff == NULL ) {
-        fprintf( stderr, "Cannot extend $PATH, malloc failed\n" );
-        exit( EXIT_FAILURE );
-    }
+    char * buff = safe_malloc( strlen( prefix ) + 1 + strlen( path ) + 1 + strlen( suffix ) + 1 );
     char * d = stpcpy( buff, prefix );
     d = stpcpy( d, ":" );
     d = stpcpy( d, path );
@@ -548,7 +540,7 @@ cat << \****
         char * home = getenv( "HOME" );
         if ( home != NULL ) {
             const char * const folder = ".poplog";
-            char * path = malloc( strlen( home ) + 1 + strlen( folder ) + 1 );
+            char * path = safe_malloc( strlen( home ) + 1 + strlen( folder ) + 1 );
             char * p = stpcpy( path, home );
             p = stpcpy( p, "/" );
             p = stpcpy( p, folder );
@@ -557,7 +549,7 @@ cat << \****
     } else {
         // Point to a specially constructed 'empty init files' folder.
         const char * const subpath = "/pop/com/noinit" ;
-        char * path = malloc( strlen( base ) + strlen( subpath ) + 1 );
+        char * path = safe_malloc( strlen( base ) + strlen( subpath ) + 1 );
         char * p = stpcpy( path, base );
         p = stpcpy( p, subpath );
         setenv( "poplib", path, !inherit_env );

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -364,7 +364,7 @@ void * safe_malloc( size_t n ) {
     return ptr;
 }
 
-void setEnvSpec( const char * envspec) {
+void setEnvSpec( const char * envspec ) {
     // envspec is a string of the form "name=val"
     char * equalpos = strchr( envspec, '=' );
     if ( equalpos == NULL ) {
@@ -386,6 +386,9 @@ void setEnvSpec( const char * envspec) {
         fprintf( stderr, "Cannot set the environment variable %s\n", envspec );
         exit( EXIT_FAILURE );
     };
+    // name and val could be freed here since setenv should copy its
+    // arguments. Steve had observed that sometimes it didn't copy the
+    // key value, so we don't free just in case.
 }
 
 #else


### PR DESCRIPTION
The change to setting `-std=c99` caused an issue on Ubuntu 20.04 and
Arch linux. It seems newer versions of GCC produce a `poplog` executable
that segfaults, whereas on Ubuntu 16.04 the executable is fine.
I'm not 100% sure why this occurs, but a few issues seem to have cropped
up after enabling `-Werror -Wpedantic -Wextra`. The use of `strncpy` is
only visible after a feature macro has been set that exposes functions
defined in the POSIX 2008 standard. `putenv` also isn't well
standardised and is generally recommended against as it doesn't take
copies of its arguments, therefore if the env spec goes out of scope,
then this actually changes the environment. In contrast, `setenv` copies
its arguments so this can't happen.

I have enabled these explicit errors permanently in the Makefile for
`poplog.c` since this is new code and we should hold ourselves to high
standards.
I have also enabled the use of POSIX 2008 via the
`-D_POSIX_C_SOURCE=200809L` compiler option.