### PR TITLE
V0.2/docker security profile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
             cd docker
             make build
       - persist_to_workspace:
-          root: _build
+          root: docker/_build
           paths:
             - artifacts/poplog_seccomp.json
   publish_github_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,8 @@ jobs:
           command: |
             cd docker
             make build
+            mkdir -p _build/artifacts
+            mv _build/poplog_seccomp.json _build/artifacts/
       - persist_to_workspace:
           root: docker/_build
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,12 +210,9 @@ jobs:
           command: |
             cd docker
             make build
-            mkdir -p _build/artifacts
-            mv _build/poplog_seccomp.json _build/artifacts/
-      - persist_to_workspace:
-          root: docker/_build
-          paths:
-            - artifacts/poplog_seccomp.json
+      - store_artifacts:
+          path: docker/_build/poplog_seccomp.json
+          destination: poplog_seccomp.json
   publish_github_release:
     docker:
       - image: cibuilds/github:0.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,8 +232,6 @@ workflows:
   version: 2
   mainflow:
     jobs:
-      - build_poplog_seccomp:
-          filters:  *default_filters
       - one_line_install:
           filters:  *default_filters
       - build_tree:
@@ -262,6 +260,12 @@ workflows:
           requires:
             - build_deb
           filters:  *default_filters
+      - build_poplog_seccomp:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+.*$/
       - publish_github_release:
           requires:
             - test_deb_1604

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,21 @@ jobs:
           root: _build
           paths:
             - artifacts/poplog_16.0.1_amd64.snap
+  build_poplog_seccomp:
+    docker:
+      - image: cimg/python:3.9.6
+    steps:
+      - run:
+          name: "Generate security profile for Poplog"
+          command: |
+            sudo apt update 
+            sudo apt install -y wget
+            cd docker
+            make build
+      - persist_to_workspace:
+          root: _build
+          paths:
+            - artifacts/poplog_seccomp.json
   publish_github_release:
     docker:
       - image: cibuilds/github:0.10
@@ -205,7 +220,6 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete "${CIRCLE_TAG}" ./_build/artifacts/
-
 default_filters: &default_filters
   # required to run on tagged releases.
   tags:
@@ -215,6 +229,8 @@ workflows:
   version: 2
   mainflow:
     jobs:
+      - build_poplog_seccomp:
+          filters:  *default_filters
       - one_line_install:
           filters:  *default_filters
       - build_tree:
@@ -254,4 +270,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+.*$/
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,11 +199,15 @@ jobs:
     docker:
       - image: cimg/python:3.9.6
     steps:
+      - checkout
+      - run:
+          name: Get system info
+          command: |
+            uname -a
+            ldd --version
       - run:
           name: "Generate security profile for Poplog"
           command: |
-            sudo apt update 
-            sudo apt install -y wget
             cd docker
             make build
       - persist_to_workspace:

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+_build/
+_download/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -31,7 +31,7 @@ deepclean: clean
 # Generate a Docker security profile
 _build/poplog_seccomp.json: _download/default.json
 	mkdir -p _build
-	python3 seccomp.py _download/default.json > $@
+	python3 seccomp.py --docker_seccomp_json=_download/default.json > $@
 
 _download/default.json:
 	mkdir -p _download

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,39 @@
+# This is an optional Makefile that is used to generate a variant security
+# profile for using Poplog under Docker. See the wiki page
+# https://github.com/GetPoplog/Seed/wiki/Running-poplog-under-Docker to learn
+# more about this topic.
+
+# Pre-requisites for using this file
+#	python3 wget
+
+.PHONY: all
+all: build
+
+.PHONY: help
+help:
+	# Valid targets are:
+	#   all, build - creates the security profile
+	#	clean - removes all build artefacts but not the _download cache.
+	#   deepclean - removes all build artefacts and also the _download cache.
+	#   help - lists the valid targets of this particular Makefile
+
+.PHONY: build
+build: _build/poplog_seccomp.json
+
+.PHONY: clean
+clean:
+	rm -rf _build
+
+.PHONY: deepclean
+deepclean: clean
+	rm -rf _download
+
+# Generate a Docker security profile
+_build/poplog_seccomp.json: _download/default.json
+	mkdir -p _build
+	python3 seccomp.py _download/default.json > $@
+
+_download/default.json:
+	mkdir -p _download
+	cd _download; wget https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,6 @@
+# Contents of the docker folder
+
+This folder is intended to house any files that are connected to using
+docker containers with Poplog.
+
+ * seccomp.py - a Python script for creating a Poplog-friendly docker default [security profile](https://docs.docker.com/engine/security/seccomp/).

--- a/docker/seccomp.py
+++ b/docker/seccomp.py
@@ -2,6 +2,8 @@
 
 import json
 import sys
+import argparse
+from pathlib import Path
 
 def loadDefault( filename ):
     with open( filename, 'r' ) as f:
@@ -17,8 +19,15 @@ def inPlaceTransform( jdata ):
         for value in [ 0x0040000, 0x0400000, 0x0440000 ]
     )
 
-if __name__ == "__main__":
-    jdata = loadDefault( sys.argv[1] )
-    inPlaceTransform( jdata )
-    json.dump( jdata, sys.stdout, indent=4 )
+parser = argparse.ArgumentParser(description="Modify default docker seccomp profile to allow syscalls needed by poplog")
+parser.add_argument("--docker_seccomp_json", type=Path, help="Path to docker's default seccomp profile")
+
+def main(argv):
+    args = parser.parse_args(argv)
+    jdata = loadDefault(args.docker_seccomp_json)
+    inPlaceTransform(jdata)
+    json.dump(jdata, sys.stdout, indent=4)
     print()
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/docker/seccomp.py
+++ b/docker/seccomp.py
@@ -8,11 +8,6 @@ def loadDefault( filename ):
         return json.load( f )
 
 def inPlaceTransform( jdata ):
-    # for names_action_etc in jdata[ 'syscalls' ]:
-    #     names = names_action_etc[ 'names' ]
-    #     action = names_action_etc[ 'action' ]
-    #     if 'personality' in names:
-    #         print( action )
     jdata[ 'syscalls' ].extend(
         { 
             "names": [ "personality" ],

--- a/docker/seccomp.py
+++ b/docker/seccomp.py
@@ -16,7 +16,7 @@ def inPlaceTransform( jdata ):
             "action": "SCMP_ACT_ALLOW",
             "args": [ { "index": 0, "value": value, "op": "SCMP_CMP_EQ" } ]
         }
-        for value in [ 0x0040000, 0x0400000, 0x0440000 ]
+        for value in [ ADDR_NO_RANDOMIZE, READ_IMPLIES_EXEC, (ADDR_NO_RANDOMIZE|READ_IMPLIES_EXEC) ]
     )
 
 parser = argparse.ArgumentParser(description="Modify default docker seccomp profile to allow syscalls needed by poplog")

--- a/docker/seccomp.py
+++ b/docker/seccomp.py
@@ -5,6 +5,9 @@ import sys
 import argparse
 from pathlib import Path
 
+ADDR_NO_RANDOMIZE = 0x0040000
+READ_IMPLIES_EXEC = 0x0400000
+
 def loadDefault( filename ):
     with open( filename, 'r' ) as f:
         return json.load( f )

--- a/docker/seccomp.py
+++ b/docker/seccomp.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import json
+import sys
+
+def loadDefault( filename ):
+    with open( filename, 'r' ) as f:
+        return json.load( f )
+
+def inPlaceTransform( jdata ):
+    # for names_action_etc in jdata[ 'syscalls' ]:
+    #     names = names_action_etc[ 'names' ]
+    #     action = names_action_etc[ 'action' ]
+    #     if 'personality' in names:
+    #         print( action )
+    jdata[ 'syscalls' ].extend(
+        { 
+            "names": [ "personality" ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [ { "index": 0, "value": value, "op": "SCMP_CMP_EQ" } ]
+        }
+        for value in [ 0x0040000, 0x0400000, 0x0440000 ]
+    )
+
+if __name__ == "__main__":
+    jdata = loadDefault( sys.argv[1] )
+    inPlaceTransform( jdata )
+    json.dump( jdata, sys.stdout, indent=4 )
+    print()


### PR DESCRIPTION
This adds a new release-only job to the CircleCI build that creates an augmented Docker security profile and adds that to the artifacts folder. The idea is to include this file on a GitHub release.

The job works by running `make build` in the `docker/` folder that in turn runs a small Python script. I chose Python for the convenience of hacking JSON. The resulting profile allows calls to `personality` that have the flags required by Poplog.