### PR TITLE
V0.2/seccomp as manual target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,24 +195,6 @@ jobs:
           root: _build
           paths:
             - artifacts/poplog_16.0.1_amd64.snap
-  build_poplog_seccomp:
-    docker:
-      - image: cimg/python:3.9.6
-    steps:
-      - checkout
-      - run:
-          name: Get system info
-          command: |
-            uname -a
-            ldd --version
-      - run:
-          name: "Generate security profile for Poplog"
-          command: |
-            cd docker
-            make build
-      - store_artifacts:
-          path: docker/_build/poplog_seccomp.json
-          destination: poplog_seccomp.json
   publish_github_release:
     docker:
       - image: cibuilds/github:0.10
@@ -260,12 +242,6 @@ workflows:
           requires:
             - build_deb
           filters:  *default_filters
-      - build_poplog_seccomp:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+.*$/
       - publish_github_release:
           requires:
             - test_deb_1604

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,12 +13,17 @@ all: build
 help:
 	# Valid targets are:
 	#   all, build - creates the security profile
+	#   update - update the poplog_seccomp.json file (best used with git)
 	#	clean - removes all build artefacts but not the _download cache.
 	#   deepclean - removes all build artefacts and also the _download cache.
 	#   help - lists the valid targets of this particular Makefile
 
 .PHONY: build
 build: _build/poplog_seccomp.json
+
+.PHONY: update
+update: _build/poplog_seccomp.json
+	cp $< .
 
 .PHONY: clean
 clean:

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,4 +3,6 @@
 This folder is intended to house any files that are connected to using
 docker containers with Poplog.
 
- * seccomp.py - a Python script for creating a Poplog-friendly docker default [security profile](https://docs.docker.com/engine/security/seccomp/).
+ * poplog_seccomp.json - a docker security profile to be used when running Poplog inside a Docker container.
+ * seccomp.py - a Python script for updating a Poplog-friendly docker default [security profile](https://docs.docker.com/engine/security/seccomp/).
+ 

--- a/docker/poplog_seccomp.json
+++ b/docker/poplog_seccomp.json
@@ -1,0 +1,792 @@
+{
+    "defaultAction": "SCMP_ACT_ERRNO",
+    "archMap": [
+        {
+            "architecture": "SCMP_ARCH_X86_64",
+            "subArchitectures": [
+                "SCMP_ARCH_X86",
+                "SCMP_ARCH_X32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_AARCH64",
+            "subArchitectures": [
+                "SCMP_ARCH_ARM"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPS64",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPS",
+                "SCMP_ARCH_MIPS64N32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPS64N32",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPS",
+                "SCMP_ARCH_MIPS64"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPSEL64",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPSEL",
+                "SCMP_ARCH_MIPSEL64N32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPSEL64N32",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPSEL",
+                "SCMP_ARCH_MIPSEL64"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_S390X",
+            "subArchitectures": [
+                "SCMP_ARCH_S390"
+            ]
+        }
+    ],
+    "syscalls": [
+        {
+            "names": [
+                "accept",
+                "accept4",
+                "access",
+                "adjtimex",
+                "alarm",
+                "bind",
+                "brk",
+                "capget",
+                "capset",
+                "chdir",
+                "chmod",
+                "chown",
+                "chown32",
+                "clock_adjtime",
+                "clock_adjtime64",
+                "clock_getres",
+                "clock_getres_time64",
+                "clock_gettime",
+                "clock_gettime64",
+                "clock_nanosleep",
+                "clock_nanosleep_time64",
+                "close",
+                "close_range",
+                "connect",
+                "copy_file_range",
+                "creat",
+                "dup",
+                "dup2",
+                "dup3",
+                "epoll_create",
+                "epoll_create1",
+                "epoll_ctl",
+                "epoll_ctl_old",
+                "epoll_pwait",
+                "epoll_pwait2",
+                "epoll_wait",
+                "epoll_wait_old",
+                "eventfd",
+                "eventfd2",
+                "execve",
+                "execveat",
+                "exit",
+                "exit_group",
+                "faccessat",
+                "faccessat2",
+                "fadvise64",
+                "fadvise64_64",
+                "fallocate",
+                "fanotify_mark",
+                "fchdir",
+                "fchmod",
+                "fchmodat",
+                "fchown",
+                "fchown32",
+                "fchownat",
+                "fcntl",
+                "fcntl64",
+                "fdatasync",
+                "fgetxattr",
+                "flistxattr",
+                "flock",
+                "fork",
+                "fremovexattr",
+                "fsetxattr",
+                "fstat",
+                "fstat64",
+                "fstatat64",
+                "fstatfs",
+                "fstatfs64",
+                "fsync",
+                "ftruncate",
+                "ftruncate64",
+                "futex",
+                "futex_time64",
+                "futimesat",
+                "getcpu",
+                "getcwd",
+                "getdents",
+                "getdents64",
+                "getegid",
+                "getegid32",
+                "geteuid",
+                "geteuid32",
+                "getgid",
+                "getgid32",
+                "getgroups",
+                "getgroups32",
+                "getitimer",
+                "getpeername",
+                "getpgid",
+                "getpgrp",
+                "getpid",
+                "getppid",
+                "getpriority",
+                "getrandom",
+                "getresgid",
+                "getresgid32",
+                "getresuid",
+                "getresuid32",
+                "getrlimit",
+                "get_robust_list",
+                "getrusage",
+                "getsid",
+                "getsockname",
+                "getsockopt",
+                "get_thread_area",
+                "gettid",
+                "gettimeofday",
+                "getuid",
+                "getuid32",
+                "getxattr",
+                "inotify_add_watch",
+                "inotify_init",
+                "inotify_init1",
+                "inotify_rm_watch",
+                "io_cancel",
+                "ioctl",
+                "io_destroy",
+                "io_getevents",
+                "io_pgetevents",
+                "io_pgetevents_time64",
+                "ioprio_get",
+                "ioprio_set",
+                "io_setup",
+                "io_submit",
+                "io_uring_enter",
+                "io_uring_register",
+                "io_uring_setup",
+                "ipc",
+                "kill",
+                "lchown",
+                "lchown32",
+                "lgetxattr",
+                "link",
+                "linkat",
+                "listen",
+                "listxattr",
+                "llistxattr",
+                "_llseek",
+                "lremovexattr",
+                "lseek",
+                "lsetxattr",
+                "lstat",
+                "lstat64",
+                "madvise",
+                "membarrier",
+                "memfd_create",
+                "mincore",
+                "mkdir",
+                "mkdirat",
+                "mknod",
+                "mknodat",
+                "mlock",
+                "mlock2",
+                "mlockall",
+                "mmap",
+                "mmap2",
+                "mprotect",
+                "mq_getsetattr",
+                "mq_notify",
+                "mq_open",
+                "mq_timedreceive",
+                "mq_timedreceive_time64",
+                "mq_timedsend",
+                "mq_timedsend_time64",
+                "mq_unlink",
+                "mremap",
+                "msgctl",
+                "msgget",
+                "msgrcv",
+                "msgsnd",
+                "msync",
+                "munlock",
+                "munlockall",
+                "munmap",
+                "nanosleep",
+                "newfstatat",
+                "_newselect",
+                "open",
+                "openat",
+                "openat2",
+                "pause",
+                "pidfd_open",
+                "pidfd_send_signal",
+                "pipe",
+                "pipe2",
+                "poll",
+                "ppoll",
+                "ppoll_time64",
+                "prctl",
+                "pread64",
+                "preadv",
+                "preadv2",
+                "prlimit64",
+                "pselect6",
+                "pselect6_time64",
+                "pwrite64",
+                "pwritev",
+                "pwritev2",
+                "read",
+                "readahead",
+                "readlink",
+                "readlinkat",
+                "readv",
+                "recv",
+                "recvfrom",
+                "recvmmsg",
+                "recvmmsg_time64",
+                "recvmsg",
+                "remap_file_pages",
+                "removexattr",
+                "rename",
+                "renameat",
+                "renameat2",
+                "restart_syscall",
+                "rmdir",
+                "rseq",
+                "rt_sigaction",
+                "rt_sigpending",
+                "rt_sigprocmask",
+                "rt_sigqueueinfo",
+                "rt_sigreturn",
+                "rt_sigsuspend",
+                "rt_sigtimedwait",
+                "rt_sigtimedwait_time64",
+                "rt_tgsigqueueinfo",
+                "sched_getaffinity",
+                "sched_getattr",
+                "sched_getparam",
+                "sched_get_priority_max",
+                "sched_get_priority_min",
+                "sched_getscheduler",
+                "sched_rr_get_interval",
+                "sched_rr_get_interval_time64",
+                "sched_setaffinity",
+                "sched_setattr",
+                "sched_setparam",
+                "sched_setscheduler",
+                "sched_yield",
+                "seccomp",
+                "select",
+                "semctl",
+                "semget",
+                "semop",
+                "semtimedop",
+                "semtimedop_time64",
+                "send",
+                "sendfile",
+                "sendfile64",
+                "sendmmsg",
+                "sendmsg",
+                "sendto",
+                "setfsgid",
+                "setfsgid32",
+                "setfsuid",
+                "setfsuid32",
+                "setgid",
+                "setgid32",
+                "setgroups",
+                "setgroups32",
+                "setitimer",
+                "setpgid",
+                "setpriority",
+                "setregid",
+                "setregid32",
+                "setresgid",
+                "setresgid32",
+                "setresuid",
+                "setresuid32",
+                "setreuid",
+                "setreuid32",
+                "setrlimit",
+                "set_robust_list",
+                "setsid",
+                "setsockopt",
+                "set_thread_area",
+                "set_tid_address",
+                "setuid",
+                "setuid32",
+                "setxattr",
+                "shmat",
+                "shmctl",
+                "shmdt",
+                "shmget",
+                "shutdown",
+                "sigaltstack",
+                "signalfd",
+                "signalfd4",
+                "sigprocmask",
+                "sigreturn",
+                "socket",
+                "socketcall",
+                "socketpair",
+                "splice",
+                "stat",
+                "stat64",
+                "statfs",
+                "statfs64",
+                "statx",
+                "symlink",
+                "symlinkat",
+                "sync",
+                "sync_file_range",
+                "syncfs",
+                "sysinfo",
+                "tee",
+                "tgkill",
+                "time",
+                "timer_create",
+                "timer_delete",
+                "timer_getoverrun",
+                "timer_gettime",
+                "timer_gettime64",
+                "timer_settime",
+                "timer_settime64",
+                "timerfd_create",
+                "timerfd_gettime",
+                "timerfd_gettime64",
+                "timerfd_settime",
+                "timerfd_settime64",
+                "times",
+                "tkill",
+                "truncate",
+                "truncate64",
+                "ugetrlimit",
+                "umask",
+                "uname",
+                "unlink",
+                "unlinkat",
+                "utime",
+                "utimensat",
+                "utimensat_time64",
+                "utimes",
+                "vfork",
+                "vmsplice",
+                "wait4",
+                "waitid",
+                "waitpid",
+                "write",
+                "writev"
+            ],
+            "action": "SCMP_ACT_ALLOW"
+        },
+        {
+            "names": [
+                "process_vm_readv",
+                "process_vm_writev",
+                "ptrace"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "minKernel": "4.8"
+            }
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 0,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 8,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 131072,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 131080,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 4294967295,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "sync_file_range2"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "ppc64le"
+                ]
+            }
+        },
+        {
+            "names": [
+                "arm_fadvise64_64",
+                "arm_sync_file_range",
+                "sync_file_range2",
+                "breakpoint",
+                "cacheflush",
+                "set_tls"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "arm",
+                    "arm64"
+                ]
+            }
+        },
+        {
+            "names": [
+                "arch_prctl"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "amd64",
+                    "x32"
+                ]
+            }
+        },
+        {
+            "names": [
+                "modify_ldt"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "amd64",
+                    "x32",
+                    "x86"
+                ]
+            }
+        },
+        {
+            "names": [
+                "s390_pci_mmio_read",
+                "s390_pci_mmio_write",
+                "s390_runtime_instr"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "s390",
+                    "s390x"
+                ]
+            }
+        },
+        {
+            "names": [
+                "open_by_handle_at"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_DAC_READ_SEARCH"
+                ]
+            }
+        },
+        {
+            "names": [
+                "bpf",
+                "clone",
+                "fanotify_init",
+                "fsconfig",
+                "fsmount",
+                "fsopen",
+                "fspick",
+                "lookup_dcookie",
+                "mount",
+                "move_mount",
+                "name_to_handle_at",
+                "open_tree",
+                "perf_event_open",
+                "quotactl",
+                "setdomainname",
+                "sethostname",
+                "setns",
+                "syslog",
+                "umount",
+                "umount2",
+                "unshare"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ]
+            }
+        },
+        {
+            "names": [
+                "clone"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 2114060288,
+                    "op": "SCMP_CMP_MASKED_EQ"
+                }
+            ],
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ],
+                "arches": [
+                    "s390",
+                    "s390x"
+                ]
+            }
+        },
+        {
+            "names": [
+                "clone"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 1,
+                    "value": 2114060288,
+                    "op": "SCMP_CMP_MASKED_EQ"
+                }
+            ],
+            "comment": "s390 parameter ordering for clone is different",
+            "includes": {
+                "arches": [
+                    "s390",
+                    "s390x"
+                ]
+            },
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ]
+            }
+        },
+        {
+            "names": [
+                "reboot"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_BOOT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "chroot"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_CHROOT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "delete_module",
+                "init_module",
+                "finit_module"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_MODULE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "acct"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_PACCT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "kcmp",
+                "pidfd_getfd",
+                "process_madvise",
+                "process_vm_readv",
+                "process_vm_writev",
+                "ptrace"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_PTRACE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "iopl",
+                "ioperm"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_RAWIO"
+                ]
+            }
+        },
+        {
+            "names": [
+                "settimeofday",
+                "stime",
+                "clock_settime"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_TIME"
+                ]
+            }
+        },
+        {
+            "names": [
+                "vhangup"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_TTY_CONFIG"
+                ]
+            }
+        },
+        {
+            "names": [
+                "get_mempolicy",
+                "mbind",
+                "set_mempolicy"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_NICE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "syslog"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYSLOG"
+                ]
+            }
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 262144,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 4194304,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 4456448,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This change incorporates a default seccomp profile as an ordinary repository file, in anticipation of needing it on CircleCI builds. To reflect this, the production of a new seccomp profile is relegated to being a manually triggered activity - via `cd docker && make update`.

I will remove the wiki page and link to that page when this PR is completed.