### PR TITLE
Options prefixed with a colon now treated as a 1-line script to Pop-11

### DIFF
--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -607,7 +607,7 @@ cat << \****
             setUpEnvironment( base, flags, envv );
             execvp( argv[1], &argv[1] );
         } else if (
-            0
+            ( argv[1][0] == ':' )    // :[EXPRESSION]
 ****
 
 # Implied pop11 commands N.B. 'ved' appears here as well but not xved.


### PR DESCRIPTION
The command tool now handles the case where:
- No subsystem is specified, so should default to Pop-11;
- An option starting with a colon is encountered, which should stop further processing of options and start pop11.