### PR TITLE
Fix inconsistent whitespace in Python files

### DIFF
--- a/systests/test_pop11.py
+++ b/systests/test_pop11.py
@@ -4,7 +4,7 @@ import re
 import glob
 import subprocess
 import pytest
-from pathlib     import Path
+from pathlib import Path
 
 here = Path( os.path.realpath( __file__ ) ).parent
 

--- a/systests/test_poplog_commander.py
+++ b/systests/test_poplog_commander.py
@@ -4,10 +4,9 @@ import re
 import glob
 import subprocess
 import pytest
-from pathlib     import Path
+from pathlib import Path
 
 here = Path( os.path.realpath( __file__ ) ).parent
-
 
 @pytest.mark.parametrize("in_file_name", glob.glob(f"{here.absolute()}/poplog_commander_tests/*.test.sh"))
 def test_poplog_commander(in_file_name):


### PR DESCRIPTION
Trivial fix to whitespace in the systests/*.py files, which we noticed during last night's code review.