### PR TITLE
Bugfix: Resolve libxt.so and libx11.so errors on Debian and Ubuntu (fixes #80)

### DIFF
--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -25,6 +25,8 @@ Depends: ${misc:Depends},
  libncurses5,
  libxext6,
  libx11-6,
+ libxt-dev,
+ libx11-dev,
  libtinfo5
 Suggests: espeak, xterm, csh
 Description: Integrated development environment for POP-11, Common Lisp, Prolog and Standard ML.


### PR DESCRIPTION
The current packages on OBS produce the following error on Debian 9/10
and Ubuntu 16.04/20.04:
```
$ poplog
;;; Warning: can't open shared object libXt.so (Inappropriate ioctl for
;;;     device)
;;; PRINT DOING
;;; DOING    :
;;; Warning: can't open shared object libXt.so (Inappropriate ioctl for
;;;     device)
;;; PRINT DOING
;;; DOING    :
;;; Warning: can't open shared object libX11.so (Inappropriate ioctl for
;;;     device)
;;; PRINT DOING
;;; DOING    :
;;; Warning: can't open shared object libX11.so (Inappropriate ioctl for
;;;     device)
;;; PRINT DOING
;;; DOING    :
Sussex Poplog (Version 16.0001 Mon Aug  2 22:16:17 UTC 2021)
Copyright (c) 1982-1999 University of Sussex. All rights reserved.

Setpop
:
```

Installing libxt-dev and libx11-dev allows poplog to be invoked without
any errors.