### PR TITLE
Bugfix: resolve CentOS 7/8 install issues (fixes #82)

### DIFF
--- a/packaging/rpm/poplog.spec.tmpl
+++ b/packaging/rpm/poplog.spec.tmpl
@@ -30,6 +30,7 @@ BuildRequires: ncurses-compat-libs
 Requires: libXext
 Requires: libX11
 Requires: libXt
+Requires: glibc(x86-32)
 # libXt-devel is needed for some reason, without it libXt.so load errors occur.
 Requires: libXt-devel
 Requires: openmotif


### PR DESCRIPTION
When trying to install on CentOS 7 or 8, from the OBS archive, I get the
following error:

```
...
Key imported successfully
Running transaction check
Error: transaction check vs depsolve:
libc.so.6 is needed by poplog-0.2.0-2.1.x86_64
libc.so.6(GLIBC_2.0) is needed by poplog-0.2.0-2.1.x86_64
```
Once `glibc.i686` has been installed, `yum install poplog` works without
error. Consequently, I have added `glibc.i686` as a runtime depenedency
of poplog.