### PR TITLE
Strip bad symlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,7 @@ build: _build/Done.proxy
 
 _build/Done.proxy: _build/MakeIndexes.proxy _build/PoplogCommander.proxy _build/NoInit.proxy _build/POPLOG_VERSION
 	find _build/poplog_base -name '*-' -exec rm -f {} \; # Remove the backup files
+	find _build/poplog_base -xtype l -exec rm -f {} \;   # Remove bad symlinks (we have some from poppackages)
 	touch $@
 
 _build/POPLOG_VERSION: _build/Base.proxy

--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,7 @@ binarytarball: $(BINARY_TARBALL)
 # Pop-tree: can be untarred and used directly (as an alternative to
 # installing via a poplog package e.g. deb/rpm etc)
 $(BINARY_TARBALL): _build/Done.proxy
+	mkdir -p "$(@D)"
 	( cd _build/poplog_base/; tar cf - pop ) | gzip > $@
 	[ -f $@ ] # Sanity check that we built the target
 


### PR DESCRIPTION
This insert a clean-up of bad-symlinks just before asserting that the build is done.

In addition, during testing, I found that the sequence `make build && make binarytarball` was failing because _build/artifacts was missing. I have included a tiny fix for this in passing.