### PR TITLE
3-in-1: Build all three variants and capture their associated environments

### DIFF
--- a/AppDir/poplog.desktop
+++ b/AppDir/poplog.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Poplog
-Exec=opt/poplog/pop/pop/poplog
+Exec=opt/poplog/pop/bin/poplog
 Icon=poplog
 Type=Application
 Terminal=true

--- a/Makefile
+++ b/Makefile
@@ -405,8 +405,8 @@ _build/NoInit.proxy: _build/Base.proxy
 _build/PoplogCommander.proxy: _build/Stage2.proxy
 	mkdir -p _build/commander
 	mkdir -p _build/poplog_base/pop/bin
-	( GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" bash makePoplogCommander.sh ) > _build/commander/poplog.c
-	( cd _build/commander && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
+	GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" bash makePoplogCommander.sh > _build/commander/poplog.c
+	cd _build/commander && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c
 	cp -f _build/commander/poplog _build/poplog_base/pop/bin/
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -403,12 +403,12 @@ _build/NoInit.proxy: _build/Base.proxy
 	touch $@
 
 _build/PoplogCommander.proxy: _build/Stage2.proxy
-	mkdir -p _build/cmdr
+	mkdir -p _build/commander
 	mkdir -p _build/poplog_base/pop/bin
-	GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" sh makePoplogCommander.sh > _build/cmdr/poplog.c
-	( cd _build/cmdr && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
+	( cd commander && GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" sh makePoplogCommander.sh ) > _build/commander/poplog.c
+	( cd _build/commander && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
 	rm -f _build/poplog_base/pop/pop/poplog
-	cp _build/cmdr/poplog _build/poplog_base/pop/bin/
+	cp _build/commander/poplog _build/poplog_base/pop/bin/
 	touch $@
 
 _build/MakeIndexes.proxy: _build/Stage2.proxy _build/Packages.proxy

--- a/Makefile
+++ b/Makefile
@@ -407,8 +407,7 @@ _build/PoplogCommander.proxy: _build/Stage2.proxy
 	mkdir -p _build/poplog_base/pop/bin
 	( GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" bash makePoplogCommander.sh ) > _build/commander/poplog.c
 	( cd _build/commander && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
-	rm -f _build/poplog_base/pop/pop/poplog
-	cp _build/commander/poplog _build/poplog_base/pop/bin/
+	cp -f _build/commander/poplog _build/poplog_base/pop/bin/
 	touch $@
 
 _build/MakeIndexes.proxy: _build/Stage2.proxy _build/Packages.proxy

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ install:
 	( cd _build/poplog_base; tar cf - . ) | ( cd $(DESTDIR)$(POPLOG_VERSION_DIR); tar xf - )
 	cd $(DESTDIR)$(POPLOG_HOME_DIR); ln -sf $(VERSION_DIR) $(SYMLINK)
 	mkdir -p $(DESTDIR)$(bindir)
-	ln -sf $(POPLOG_VERSION_SYMLINK)/pop/pop/poplog $(DESTDIR)$(bindir)/
+	ln -sf $(POPLOG_VERSION_SYMLINK)/pop/bin/poplog $(DESTDIR)$(bindir)/
 	# Target "install" completed
 
 .PHONY: install-poplocal
@@ -404,10 +404,11 @@ _build/NoInit.proxy: _build/Base.proxy
 
 _build/PoplogCommander.proxy: _build/Stage2.proxy
 	mkdir -p _build/cmdr
+	mkdir -p _build/poplog_base/pop/bin
 	GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" sh makePoplogCommander.sh > _build/cmdr/poplog.c
 	( cd _build/cmdr && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
 	rm -f _build/poplog_base/pop/pop/poplog
-	cp _build/cmdr/poplog _build/poplog_base/pop/pop/
+	cp _build/cmdr/poplog _build/poplog_base/pop/bin/
 	touch $@
 
 _build/MakeIndexes.proxy: _build/Stage2.proxy _build/Packages.proxy
@@ -631,7 +632,7 @@ buildappimage: _download/appimagetool
 	cd _build/AppDir/usr/lib; for i in *.so.*; do ln -s $$i `echo "$$i" | sed 's/\.so\.[^.]*$$/.so/'`; done
 	chmod a-w _build/AppDir/usr/lib/*
 	mkdir -p _build/AppDir/usr/bin
-	cd _build/AppDir/usr/bin; ln -s ../..$(POPLOG_VERSION_DIR)/pop/pop/poplog .
+	cd _build/AppDir/usr/bin; ln -s ../..$(POPLOG_VERSION_DIR)/pop/bin/poplog .
 	cd _build && ARCH=x86_64 ../_download/appimagetool AppDir
 
 
@@ -658,7 +659,7 @@ buildsnapcraftready:
 	mkdir -p _build/dotsnap$(PREBUILT_DIR)$(POPLOG_VERSION_DIR)
 	mkdir -p _build/dotsnap$(PREBUILT_DIR)/usr/bin
 	cat "$(BINARY_TARBALL)" | ( cd _build/dotsnap$(PREBUILT_DIR)$(POPLOG_VERSION_DIR); tar zxf - )
-	cd _build/dotsnap$(PREBUILT_DIR)/usr/bin; ln -s ../..$(POPLOG_VERSION_DIR)/pop/pop/poplog .
+	cd _build/dotsnap$(PREBUILT_DIR)/usr/bin; ln -s ../..$(POPLOG_VERSION_DIR)/pop/bin/poplog .
 	cp snapcraft.yaml _build/dotsnap
 
 

--- a/Makefile
+++ b/Makefile
@@ -434,8 +434,8 @@ _build/Packages.proxy: _download/packages-V$(MAJOR_VERSION).tar.bz2 _build/Base.
 # This target ensures that we rebuild popc, poplink, poplibr on top of the fresh corepop.
 # It is effectively Waldek's build_pop2 script.
 _build/Stage2.proxy: _build/Stage1.proxy _build/Newpop.proxy
-	sh makeSystemTools.sh
-	sh makeStage2.sh
+	bash makeSystemTools.sh
+	bash makeStage2.sh
 	touch $@
 
 _build/Newpop.proxy: _build/poplog_base/pop/pop/newpop.psv
@@ -451,8 +451,8 @@ _build/poplog_base/pop/pop/newpop.psv: _build/Stage1.proxy
 # This target ensures that we have a working popc, poplink, poplibr and a fresh corepop
 # in newpop11. It is the equivalent of Waldek's build_pop0 script.
 _build/Stage1.proxy: _build/Corepops.proxy
-	sh makeSystemTools.sh
-	sh relinkCorepop.sh
+	bash makeSystemTools.sh
+	bash relinkCorepop.sh
 	cp _build/poplog_base/pop/pop/newpop11 _build/poplog_base/pop/pop/corepop
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ _build/NoInit.proxy: _build/Base.proxy
 _build/PoplogCommander.proxy: _build/Stage2.proxy
 	mkdir -p _build/commander
 	mkdir -p _build/poplog_base/pop/bin
-	( cd commander && GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" bash makePoplogCommander.sh ) > _build/commander/poplog.c
+	( GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" bash makePoplogCommander.sh ) > _build/commander/poplog.c
 	( cd _build/commander && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
 	rm -f _build/poplog_base/pop/pop/poplog
 	cp _build/commander/poplog _build/poplog_base/pop/bin/

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ _build/NoInit.proxy: _build/Base.proxy
 _build/PoplogCommander.proxy: _build/Stage2.proxy
 	mkdir -p _build/commander
 	mkdir -p _build/poplog_base/pop/bin
-	( cd commander && GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" sh makePoplogCommander.sh ) > _build/commander/poplog.c
+	( cd commander && GETPOPLOG_VERSION="$(GETPOPLOG_VERSION)" bash makePoplogCommander.sh ) > _build/commander/poplog.c
 	( cd _build/commander && $(CC) $(CFLAGS) -Wextra -Werror -Wpedantic -o poplog poplog.c )
 	rm -f _build/poplog_base/pop/pop/poplog
 	cp _build/commander/poplog _build/poplog_base/pop/bin/

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -705,7 +705,7 @@ cat << \****
             if ( inherit_env ) {
                 char * use_build = getenv( "POPLOG_USE_BUILD" );
                 if ( use_build == NULL ) {
-                    use_build = "xt"; 
+                    use_build = "xm"; 
                 }
                 if ( 0 ) {
                     // Skip
@@ -719,7 +719,7 @@ done
 
 cat << \****
                 } else {
-                    xt_setUpEnvVars( base, inherit_env );
+                    xm_setUpEnvVars( base, inherit_env );
                 }
             } else {
                 nox_setUpEnvVars( base, inherit_env );

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -12,8 +12,15 @@ set -euo pipefail
 # DEFAULT_RUN_VARIANT is the default for scripts.
 ################################################################################
 
-VARIANT_BUILDS=(nox xt xm)
+# The options are what the user types. They have to be translated into builds.
+# e.g. --gui=xt has to become xt. The reason for that is that the 'editions'
+# of Poplog relate to the mutually exclusive build options. The mapping is 
+# implicitly defined by matching position in the two (congruent) arrays.
 VARIANT_OPTIONS=(--no-gui --gui=xt --gui=motif)
+VARIANT_BUILDS=(nox xt xm)
+
+# And the defaults are defined in terms of builds rather than options. That is
+# because they are entirely internal constants.
 DEFAULT_DEV_VARIANT=xm
 DEFAULT_RUN_VARIANT=nox
 

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -659,15 +659,20 @@ void extendPath( char * prefix, char * path, char * suffix ) {
 
 ****
 
+env_file_to_c_code() {
+    filename="$1"
+    cat "$filename" \
+    | sed -e 's/"/\\"/g' \
+    | sed -e 's/\([^=]\+\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'    
+}
+
 # Here we create three functions for setting the environment variables that
 # are unique to the build variants: nox, xm, xt. These will be called
 # nox_setUpEnvVars, xm_setUpEnvVars, xt_setUpEnvVars.
 for variant in "${VARIANT_BUILDS[@]}"
 do
     echo "void ${variant}_setUpEnvVars( char * base, bool inherit_env ) {"
-    cat _build/environments/$variant.env \
-    | sed -e 's/"/\\"/g' \
-    | sed -e 's/\([^=]\+\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'
+    env_file_to_c_code "_build/environments/${variant}.env"
     echo "}"
     echo
 done
@@ -721,10 +726,7 @@ cat << ****
 ****
 
 # Now we squirt in the shared environment variables.
-cat _build/environments/shared.env \
-| sed -e 's/"/\\"/g' \
-| sed -e 's/\([^=]*\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'
-
+env_file_to_c_code "_build/environments/shared.env"
 echo 
 
 ################################################################################

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -342,10 +342,20 @@ poplog (pop11|prolog|clisp|pml) [OPTION]... [VEDCOMMAND] [FILE]...
      %nobanner
          Suppress printing of the Poplog banner.
 
-    These interpreter commands have four different argument-patterns:
+    These interpreter commands (pop11, prolog, clisp, pml) have four different 
+    argument-patterns:
 
     1. If no other arguments are given, this will start a read-eval-print loop
-    (REPL) in the specified language.
+    (REPL) in the specified language. For example:
+
+        % poplog pop11
+
+        Sussex Poplog (Version 16.0001 Thu 12 Aug 00:47:01 BST 2021)
+        Copyright (c) 1982-1999 University of Sussex. All rights reserved.
+
+        Setpop
+        : 
+
 
     2. If a file argument is given, this will start Poplog in the specified
     language, load and run the file and then exit. This implies --noinit.
@@ -387,7 +397,7 @@ poplog [OPTION]... (help|teach|doc|ref) [TOPIC]
     If found opens a buffer in the editor and otherwise drops into a REPL.
 
 
-RESTRICTED AND UNRESTRICTED MODE
+MODES
 
 poplog --run [OPTION]...
     This option forces the Poplog to use the pre-set defaults for all 
@@ -401,6 +411,20 @@ poplog --dev [OPTION]...
     variables and runs the $poplib/init.p and $poplib/vedinit.p. This is the
     normal mode for programming in Poplog. It is not normally necessary to
     supply this option.
+
+poplog --use-build=(nox|xt|xm) [OPTION]...
+    This option selects the build-variant of Poplog. Poplog can be built
+    without X-windows (nox), with the X-Toolkit (xt) or with Motif (xm).
+    This mainly affects the availability of xved and its look and feel.
+    
+    If this option is not specified then the default depends on whether 
+    poplog is being run interactively (--dev) or as a script (--run).
+    In interactive mode, the environment variable $POPLOG_USE_BUILD is checked, 
+    which should have one of the three values nox, xt or xm. Otherwise it 
+    falls back to xm (Motif).
+
+    When poplog is being run as a script (--run) then the default is nox
+    (run without X-windows).
 
 
 UTILITY ACTIONS

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -86,7 +86,7 @@ cat << \****
 #define PREFER_SECURITY     0x0
 #define PREFER_FLEXIBILITY  (RUN_INIT_P|INHERIT_ENV)
 //  Bit-flag sets for variants.
-#define VARIANT_FLAGS       0xC
+#define VARIANT_FLAGS       (VARIANT_X | VARIANT_MOTIF)
 #define VARIANT_NOX         0x0
 #define VARIANT_XT          (VARIANT_X)
 #define VARIANT_XM          (VARIANT_X | VARIANT_MOTIF)
@@ -667,7 +667,7 @@ do
     echo "void ${variant}_setUpEnvVars( char * base, bool inherit_env ) {"
     cat _build/environments/$variant.env \
     | sed -e 's/"/\\"/g' \
-    | sed -e 's/\([^=]*\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'
+    | sed -e 's/\([^=]+\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'
     echo "}"
     echo
 done

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 # implicitly defined by matching position in the two (congruent) arrays.
 VARIANT_OPTIONS=(--no-gui --gui=xt --gui=motif)
 VARIANT_BUILDS=(nox xt xm)
+# Sanity check
+[[ ${#VARIANT_OPTIONS[@]} -eq ${#VARIANT_BUILDS[@]} ]] || { echo "VARIANT_OPTIONS should have the same number of items as VARIANT_BUILDS but did not"; exit 1; }
 
 # And the defaults are defined in terms of builds rather than options. That is
 # because they are entirely internal constants.
@@ -857,7 +859,7 @@ cat << \****
             if ( 0 ) {
                 // Never taken - a trick to regularise the following cases.
 ****
-for n in {0..2}
+for ((n=0; n<${#VARIANT_OPTIONS[@]}; n++)) do
 do
     option="${VARIANT_OPTIONS[n]}"
     build="${VARIANT_BUILDS[n]}"

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -63,7 +63,7 @@ cat << \****
 #define PREFER_SECURITY     0x0
 #define PREFER_FLEXIBILITY  (RUN_INIT_P|INHERIT_ENV)
 //  Bit-flag sets for variants.
-#define VARIANT_FLAGS       0x12
+#define VARIANT_FLAGS       0xC
 #define VARIANT_NOX         0x0
 #define VARIANT_XT          (VARIANT_X)
 #define VARIANT_XM          (VARIANT_X | VARIANT_MOTIF)
@@ -564,7 +564,7 @@ done
 
 cat << \****
         default:
-            mishap( "Invalid use-build" );
+            mishap( "Invalid use-build: %d", vflags );
             break;
     }
 

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -7,14 +7,26 @@ set -euo pipefail
 # used.
 
 ################################################################################
+# We bundle the three build variants and defaults into some environment
+# variables. DEFAULT_DEV_VARIANT is the right default for interactive work.
+# DEFAULT_RUN_VARIANT is the default for scripts.
+################################################################################
+
+VARIANTS=(nox xt xm)
+DEFAULT_DEV_VARIANT=xm
+DEFAULT_RUN_VARIANT=nox
+
+
+################################################################################
 # Refine the files containing env bindings for the 3 variants of Poplog.
 # We start from nox-new, xt-new and xm-new, all inside _build/environments.
 ################################################################################
 
 # Verify that the base files are valid.
-if !( cd _build/environments && cmp nox-base nox-base-cmp && cmp xt-base xt-base-cmp && cmp xm-base xm-base-cmp ); then \;
-    echo "GetPoplog - cannot determine environment variables for Poplog" >&2 \;
-    exit 1 \;
+if !( cd _build/environments && cmp nox-base nox-base-cmp && cmp xt-base xt-base-cmp && cmp xm-base xm-base-cmp )
+then
+    echo "GetPoplog - cannot determine environment variables for Poplog" >&2
+    exit 1
 fi
 
 # Find lines that are common to all three.
@@ -23,11 +35,10 @@ fi
 )
 
 # Remove common lines from each.
-( cd _build/environments && \
-    comm -23 nox-new shared.env > nox.env && \
-    comm -23 xt-new shared.env > xt.env && \
-    comm -23 xm-new shared.env > xm.env \
-)
+for build_type in "${VARIANTS[@]}"
+do 
+    ( cd _build/environments && comm -23 "${build_type}-new" shared.env > ${build_type}.env )
+done
 
 
 ################################################################################
@@ -629,9 +640,6 @@ void extendPath( char * prefix, char * path, char * suffix ) {
 # Here we create three functions for setting the environment variables that
 # are unique to the build variants: nox, xm, xt. These will be called
 # nox_setUpEnvVars, xm_setUpEnvVars, xt_setUpEnvVars.
-VARIANTS=(nox xt xm)
-DEFAULT_DEV_VARIANT=xm
-DEFAULT_RUN_VARIANT=nox
 for variant in "${VARIANTS[@]}"
 do
     echo "void ${variant}_setUpEnvVars( char * base, bool inherit_env ) {"

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -35,13 +35,16 @@ DEFAULT_RUN_VARIANT=nox
 BUILD_HOME=`pwd`/_build
 
 # In process_env we take lines of the form VAR=VALUE and escape the characters
-# of the RHS using the conventions of the C-strings.
+# of the RHS using the conventions of the C-strings. 
 
 # Note that we do not wish to capture the values of variables automatically
 # introduced by running a shell SHLVL and PWD. Nor do we want to capture
 # the folder location variables poplib, poplocalauto, poplocalbin. That is
 # because GetPoplog has different defaults for those and the old values are
 # irrelevant.
+
+# N.B. It is in this function that we change from null-separated back to
+# newline separated lines.
 
 process_env() {
     build="$1"

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -34,6 +34,9 @@ DEFAULT_RUN_VARIANT=nox
 
 BUILD_HOME=`pwd`/_build
 
+# In process_env we take lines of the form VAR=VALUE and escape the characters
+# of the RHS using the conventions of the C-strings.
+
 # Note that we do not wish to capture the values of variables automatically
 # introduced by running a shell SHLVL and PWD. Nor do we want to capture
 # the folder location variables poplib, poplocalauto, poplocalbin. That is
@@ -683,11 +686,10 @@ void extendPath( char * prefix, char * path, char * suffix ) {
 
 ****
 
+# Transform the VAR=VALUE shape into the final C-code.
 env_file_to_c_code() {
     filename="$1"
     cat "$filename" \
-    | sed -e 's/"/\\"/g' \
-    | sed -e 's/\\/\\\\/g' \
     | sed -e 's/\([^=]\+\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'    
 }
 

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -667,7 +667,7 @@ do
     echo "void ${variant}_setUpEnvVars( char * base, bool inherit_env ) {"
     cat _build/environments/$variant.env \
     | sed -e 's/"/\\"/g' \
-    | sed -e 's/\([^=]+\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'
+    | sed -e 's/\([^=]\+\)=\(.*\)/    setEnvReplacingUSEPOP( "\1", "\2", base, inherit_env );/'
     echo "}"
     echo
 done

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -859,7 +859,7 @@ cat << \****
             if ( 0 ) {
                 // Never taken - a trick to regularise the following cases.
 ****
-for ((n=0; n<${#VARIANT_OPTIONS[@]}; n++)) do
+for ((n=0; n<${#VARIANT_OPTIONS[@]}; n++))
 do
     option="${VARIANT_OPTIONS[n]}"
     build="${VARIANT_BUILDS[n]}"

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -415,12 +415,13 @@ cat << \****
 const char * const USEPOP = USEPOP_LITERAL;
 
 void truncatePopCom( char * base ) {
-    const char * const required_suffix = "/pop/pop";
+    const char * const required_suffix = "/pop/bin";
     size_t len = strlen( base );
     if ( strcmp( required_suffix, &base[ len - 8 ] ) == 0 ) {
         base[ len - strlen( required_suffix ) ] = '\0';
     } else {
         fprintf( stderr, "Poplog installation folder missing $popsys folder\n" );
+        fprintf( stderr, "Base folder is: %s\n", base );
         exit( EXIT_FAILURE );
     }
 }

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -675,12 +675,13 @@ do
     echo "            break;"
 done
 
+# We have to default to 'xt' at the moment because the 'xm' build has issues.
 cat << \****
         default:
             if ( inherit_env ) {
                 char * use_build = getenv( "POPLOG_USE_BUILD" );
                 if ( use_build == NULL ) {
-                    use_build = "xm";
+                    use_build = "xt"; 
                 }
                 if ( 0 ) {
                     // Skip
@@ -694,7 +695,7 @@ done
 
 cat << \****
                 } else {
-                    xm_setUpEnvVars( base, inherit_env );
+                    xt_setUpEnvVars( base, inherit_env );
                 }
             } else {
                 nox_setUpEnvVars( base, inherit_env );

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
 BUILD_HOME=`pwd`/_build
 usepop=`pwd`/_build/poplog_base

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 
+BUILD_HOME=`pwd`/_build
 usepop=`pwd`/_build/poplog_base
 export usepop
 . $usepop/pop/com/popinit.sh
@@ -40,5 +41,65 @@ cd $usepop/pop/x/src/
 # $usepop/pop/src/newpop -link -nox -norsv
 # $usepop/pop/src/newpop -link -x=-xm -norsv
 # $usepop/pop/src/newpop -link -x=-xt -norsv
+
+mkdir -p ${BUILD_HOME}/environments
+
+# We need to capture the Poplog environment for each build variant.
+echo_env() {
+    cmd='(usepop="'"$1"'" && . $usepop/pop/com/popenv.sh && env)'
+    env -i sh -c "$cmd" | sort | \
+    grep -v '^\(_\|SHLVL\|PWD\|poplib\|poplocal\(auto\|bin\)\?\)=' | \
+    sed -e 's!'"$1"'![//USEPOP//]!g'
+}
+
+### Xt #########################################################################
+
+$usepop/pop/src/newpop -link -x=-xt -norsv
+
+echo_env "$usepop" > ${BUILD_HOME}/environments/xt
+echo_env "$usepop/pop/.." > ${BUILD_HOME}/environments/xt-cmp
+( cd ${BUILD_HOME}/environments && \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xt!g' < xt | \
+  sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xt/!g' > xt-new )
+
+mkdir -p $usepop/pop/pop-xt
+mkdir -p $usepop/pop/lib/psv-xt
+( cd $usepop/pop/pop; tar cf - . ) | ( cd $usepop/pop/pop-xt; tar xf - )
+( cd $usepop/pop/lib/psv; tar cf - . ) | ( cd $usepop/pop/lib/psv-xt; tar xf - )
+
+
+### motif ######################################################################
+
 $usepop/pop/src/newpop -link -x=-xm -norsv
 
+echo_env "$usepop" > ${BUILD_HOME}/environments/xm
+echo_env "$usepop/pop/.." > ${BUILD_HOME}/environments/xm-cmp
+( cd ${BUILD_HOME}/environments && \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xm!g' < xm | \
+  sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xm/!g' > xm-new )
+
+mkdir -p $usepop/pop/pop-xm
+mkdir -p $usepop/pop/lib/psv-xm
+( cd $usepop/pop/pop; tar cf - . ) | ( cd $usepop/pop/pop-xm; tar xf - )
+( cd $usepop/pop/lib/psv; tar cf - . ) | ( cd $usepop/pop/lib/psv-xm; tar xf - )
+
+
+### nox ########################################################################
+
+$usepop/pop/src/newpop -link -nox -norsv
+
+echo_env "$usepop" > ${BUILD_HOME}/environments/nox
+echo_env "$usepop/pop/.." > ${BUILD_HOME}/environments/nox-cmp
+( cd ${BUILD_HOME}/environments && \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-nox!g' < nox | \
+  sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-nox/!g' > nox-new )
+
+# Rename rather than copy.
+mv $usepop/pop/pop $usepop/pop/pop-nox
+mv $usepop/pop/lib/psv $usepop/pop/lib/psv-nox
+
+################################################################################
+
+# Choose our default build variant.
+ln -sf pop-nox $usepop/pop/pop
+ln -sf psv-nox $usepop/pop/lib/psv

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -101,5 +101,5 @@ mv "$usepop"/pop/lib/psv "$usepop"/pop/lib/psv-nox
 ################################################################################
 
 # Choose our default build variant.
-ln -sf pop-nox "$usepop/pop/pop"
-ln -sf psv-nox "$usepop/pop/lib/psv"
+ln -sf pop-xm "$usepop/pop/pop"
+ln -sf psv-xm "$usepop/pop/lib/psv"

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -54,6 +54,8 @@ echo_env() {
 
 ### Xt #########################################################################
 
+# Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
+# -x=xt specifies basepop11 should be linked against the X-toolkit.
 $usepop/pop/src/newpop -link -x=-xt -norsv
 
 echo_env "$usepop" > "${BUILD_HOME}/environments/xt"
@@ -70,6 +72,8 @@ mkdir -p "$usepop"/pop/lib/psv-xt
 
 ### motif ######################################################################
 
+# Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
+# -x=xm specifies basepop11 should be linked against the Motif-toolkit.
 $usepop/pop/src/newpop -link -x=-xm -norsv
 
 echo_env "$usepop" > "${BUILD_HOME}/environments/xm"
@@ -86,6 +90,8 @@ mkdir -p "$usepop"/pop/lib/psv-xm
 
 ### nox ########################################################################
 
+# Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
+# -nox specifies basepop11 should not be linked against X-windows.
 $usepop/pop/src/newpop -link -nox -norsv
 
 echo_env "$usepop" > "${BUILD_HOME}/environments/nox"

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -60,10 +60,10 @@ echo_env() {
 # -nox specifies basepop11 should not be linked against X-windows.
 $usepop/pop/src/newpop -link -nox -norsv
 
-echo_env "$usepop" > "${BUILD_HOME}/environments/nox"
-echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/nox-cmp"
+echo_env "$usepop" > "${BUILD_HOME}/environments/nox-base"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/nox-base-cmp"
 ( cd "${BUILD_HOME}/environments" && \
-  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-nox!g' < nox | \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-nox!g' < nox-base | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-nox/!g' > nox-new )
 
 mkdir -p "$usepop"/pop/pop-nox
@@ -78,10 +78,10 @@ mkdir -p "$usepop"/pop/lib/psv-nox
 # -x=xm specifies basepop11 should be linked against the Motif-toolkit.
 $usepop/pop/src/newpop -link -x=-xm -norsv
 
-echo_env "$usepop" > "${BUILD_HOME}/environments/xm"
-echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xm-cmp"
+echo_env "$usepop" > "${BUILD_HOME}/environments/xm-base"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xm-base-cmp"
 ( cd "${BUILD_HOME}/environments" && \
-  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xm!g' < xm | \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xm!g' < xm-base | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xm/!g' > xm-new )
 
 mkdir -p "$usepop"/pop/pop-xm
@@ -97,10 +97,10 @@ mkdir -p "$usepop"/pop/lib/psv-xm
 # -x=xt specifies basepop11 should be linked against the X-toolkit.
 $usepop/pop/src/newpop -link -x=-xt -norsv
 
-echo_env "$usepop" > "${BUILD_HOME}/environments/xt"
-echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xt-cmp"
+echo_env "$usepop" > "${BUILD_HOME}/environments/xt-base"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xt-base-cmp"
 ( cd "${BUILD_HOME}/environments" && \
-  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xt!g' < xt | \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xt!g' < xt-base | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xt/!g' > xt-new )
 
 # Rename rather than copy.

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -45,11 +45,25 @@ cd $usepop/pop/x/src/
 mkdir -p "${BUILD_HOME}/environments"
 
 # We need to capture the Poplog environment for each build variant.
+# We run the popenv.sh script inside a clean environment to capture the 
+# set of environment variables needed. We then need to replace any matches
+# of the string "_build/poplog_base" ($usepop) with our unique value USEPOP.
+# This will allow us to dynamically substitute with the selfHome'd value
+# at run-time. 
+#
+# This is inherently a weak strategy because it relies on being able to 
+# identify substitutions of $usepop. We improve its robustness by doing the
+# process twice with different values of $usepop - using the '..' trick.
+# If the resultant code is not identical we have a problem and we halt.
+# (N.B It is probably not necessary to run the variables through sort but I 
+# couldn't find a clear guarantee that env generates a sorted list.)
+#
 echo_env() {
     cmd='(usepop="'"$1"'" && . $usepop/pop/com/popenv.sh && env)'
     env -i sh -c "$cmd" | sort | \
     grep -v '^\(_\|SHLVL\|PWD\|poplib\|poplocal\(auto\|bin\)\?\)=' | \
-    sed -e 's!'"$1"'![//USEPOP//]!g'
+    sed -e 's!'"$1"'![//USEPOP//]!g' | \
+    sort
 }
 
 

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -50,6 +50,12 @@ mkdir -p "${BUILD_HOME}/environments"
 # and values. So we capture these and later on will synthesise them into 
 # C-code functions. This is the best point at which to capture the variables.
 
+# Note that we do not wish to capture the values of variables automatically
+# introduced by running a shell SHLVL and PWD. Nor do we want to capture
+# the folder location variables poplib, poplocalauto, poplocalbin. That is
+# because GetPoplog has different defaults for those and the old values are
+# irrelevant.
+
 # We run the popenv.sh script inside a clean environment to capture the 
 # set of environment variables needed. We then need to replace any matches
 # of the string "_build/poplog_base" ($usepop) with our unique value USEPOP.

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -55,6 +55,7 @@ echo_env() {
 
 ### nox ########################################################################
 
+# Newpop - see https://raw.githubusercontent.com/GetPoplog/Base/main/pop/help/newpop
 # Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
 # -nox specifies basepop11 should not be linked against X-windows.
 $usepop/pop/src/newpop -link -nox -norsv
@@ -72,6 +73,7 @@ mkdir -p "$usepop"/pop/lib/psv-nox
 
 ### motif ######################################################################
 
+# Newpop - see https://raw.githubusercontent.com/GetPoplog/Base/main/pop/help/newpop
 # Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
 # -x=xm specifies basepop11 should be linked against the Motif-toolkit.
 $usepop/pop/src/newpop -link -x=-xm -norsv
@@ -90,6 +92,7 @@ mkdir -p "$usepop"/pop/lib/psv-xm
 
 ### Xt #########################################################################
 
+# Newpop - see https://raw.githubusercontent.com/GetPoplog/Base/main/pop/help/newpop
 # Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
 # -x=xt specifies basepop11 should be linked against the X-toolkit.
 $usepop/pop/src/newpop -link -x=-xt -norsv

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -70,24 +70,6 @@ mkdir -p "$usepop"/pop/lib/psv-xt
 ( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-xt; tar xf - )
 
 
-### motif ######################################################################
-
-# Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
-# -x=xm specifies basepop11 should be linked against the Motif-toolkit.
-$usepop/pop/src/newpop -link -x=-xm -norsv
-
-echo_env "$usepop" > "${BUILD_HOME}/environments/xm"
-echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xm-cmp"
-( cd "${BUILD_HOME}/environments" && \
-  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xm!g' < xm | \
-  sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xm/!g' > xm-new )
-
-mkdir -p "$usepop"/pop/pop-xm
-mkdir -p "$usepop"/pop/lib/psv-xm
-( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-xm; tar xf - )
-( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-xm; tar xf - )
-
-
 ### nox ########################################################################
 
 # Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
@@ -100,9 +82,27 @@ echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/nox-cmp"
   sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-nox!g' < nox | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-nox/!g' > nox-new )
 
+mkdir -p "$usepop"/pop/pop-nox
+mkdir -p "$usepop"/pop/lib/psv-nox
+( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-nox; tar xf - )
+( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-nox; tar xf - )
+
+### motif ######################################################################
+
+# Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
+# -x=xm specifies basepop11 should be linked against the Motif-toolkit.
+$usepop/pop/src/newpop -link -x=-xm -norsv
+
+echo_env "$usepop" > "${BUILD_HOME}/environments/xm"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xm-cmp"
+( cd "${BUILD_HOME}/environments" && \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xm!g' < xm | \
+  sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xm/!g' > xm-new )
+
 # Rename rather than copy.
-mv "$usepop"/pop/pop "$usepop"/pop/pop-nox
-mv "$usepop"/pop/lib/psv "$usepop"/pop/lib/psv-nox
+mv "$usepop"/pop/pop "$usepop"/pop/pop-xm
+mv "$usepop"/pop/lib/psv "$usepop"/pop/lib/psv-xm
+
 
 ################################################################################
 

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -52,23 +52,6 @@ echo_env() {
     sed -e 's!'"$1"'![//USEPOP//]!g'
 }
 
-### Xt #########################################################################
-
-# Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
-# -x=xt specifies basepop11 should be linked against the X-toolkit.
-$usepop/pop/src/newpop -link -x=-xt -norsv
-
-echo_env "$usepop" > "${BUILD_HOME}/environments/xt"
-echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xt-cmp"
-( cd "${BUILD_HOME}/environments" && \
-  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xt!g' < xt | \
-  sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xt/!g' > xt-new )
-
-mkdir -p "$usepop"/pop/pop-xt
-mkdir -p "$usepop"/pop/lib/psv-xt
-( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-xt; tar xf - )
-( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-xt; tar xf - )
-
 
 ### nox ########################################################################
 
@@ -99,13 +82,31 @@ echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xm-cmp"
   sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xm!g' < xm | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xm/!g' > xm-new )
 
+mkdir -p "$usepop"/pop/pop-xm
+mkdir -p "$usepop"/pop/lib/psv-xm
+( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-xm; tar xf - )
+( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-xm; tar xf - )
+
+
+### Xt #########################################################################
+
+# Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
+# -x=xt specifies basepop11 should be linked against the X-toolkit.
+$usepop/pop/src/newpop -link -x=-xt -norsv
+
+echo_env "$usepop" > "${BUILD_HOME}/environments/xt"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xt-cmp"
+( cd "${BUILD_HOME}/environments" && \
+  sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xt!g' < xt | \
+  sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xt/!g' > xt-new )
+
 # Rename rather than copy.
-mv "$usepop"/pop/pop "$usepop"/pop/pop-xm
-mv "$usepop"/pop/lib/psv "$usepop"/pop/lib/psv-xm
+mv "$usepop"/pop/pop "$usepop"/pop/pop-xt
+mv "$usepop"/pop/lib/psv "$usepop"/pop/lib/psv-xt
 
 
 ################################################################################
 
-# Choose our default build variant.
-ln -sf pop-xm "$usepop/pop/pop"
-ln -sf psv-xm "$usepop/pop/lib/psv"
+# Choose our default build variant. 
+ln -sf pop-xt "$usepop/pop/pop"
+ln -sf psv-xt "$usepop/pop/lib/psv"

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -71,6 +71,11 @@ echo_env() {
     sort
 }
 
+# Utility to copy contents from one existing folder to another existing folder.
+tar_fromdir_todir() {
+    ( cd "$1"; tar cf - . ) | ( cd "$2"; tar xf - )
+}
+
 ### nox ########################################################################
 
 # Newpop - see https://raw.githubusercontent.com/GetPoplog/Base/main/pop/help/newpop
@@ -90,8 +95,8 @@ echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/nox-base-cmp"
 
 mkdir -p "$usepop"/pop/pop-nox
 mkdir -p "$usepop"/pop/lib/psv-nox
-( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-nox; tar xf - )
-( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-nox; tar xf - )
+tar_fromdir_todir "$usepop"/pop/pop{,-nox}
+tar_fromdir_todir "$usepop"/pop/lib/psv{,-nox}
 
 ### motif ######################################################################
 
@@ -109,8 +114,8 @@ echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xm-base-cmp"
 
 mkdir -p "$usepop"/pop/pop-xm
 mkdir -p "$usepop"/pop/lib/psv-xm
-( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-xm; tar xf - )
-( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-xm; tar xf - )
+tar_fromdir_todir "$usepop"/pop/pop{,-xm}
+tar_fromdir_todir "$usepop"/pop/lib/psv{,-xm}
 
 
 ### Xt #########################################################################
@@ -129,7 +134,7 @@ echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xt-base-cmp"
 
 # Rename rather than copy.
 mv "$usepop/pop"/pop{,-xt}
-mv "$usepop"/pop/lib/psv "$usepop"/pop/lib/psv-xt
+mv "$usepop"/pop/lib/psv{,-xt}
 
 
 ################################################################################

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -58,7 +58,11 @@ mkdir -p "${BUILD_HOME}/environments"
 
 # We don't want the exact paths - we need to abstract over $usepop. And we
 # also need to modify $usepop/pop/pop and $usepop/pop/lib/psv to include the
-# $build.
+# $build. 
+
+# N.B. We work in null-separated lines here, giving us a much better chance
+# in converting newlines and other control characters to valid C-strings later 
+# on.
 
 echo_env() {
     build="$2"

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -42,7 +42,7 @@ cd $usepop/pop/x/src/
 # $usepop/pop/src/newpop -link -x=-xm -norsv
 # $usepop/pop/src/newpop -link -x=-xt -norsv
 
-mkdir -p ${BUILD_HOME}/environments
+mkdir -p "${BUILD_HOME}/environments"
 
 # We need to capture the Poplog environment for each build variant.
 echo_env() {
@@ -56,50 +56,50 @@ echo_env() {
 
 $usepop/pop/src/newpop -link -x=-xt -norsv
 
-echo_env "$usepop" > ${BUILD_HOME}/environments/xt
-echo_env "$usepop/pop/.." > ${BUILD_HOME}/environments/xt-cmp
-( cd ${BUILD_HOME}/environments && \
+echo_env "$usepop" > "${BUILD_HOME}/environments/xt"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xt-cmp"
+( cd "${BUILD_HOME}/environments" && \
   sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xt!g' < xt | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xt/!g' > xt-new )
 
-mkdir -p $usepop/pop/pop-xt
-mkdir -p $usepop/pop/lib/psv-xt
-( cd $usepop/pop/pop; tar cf - . ) | ( cd $usepop/pop/pop-xt; tar xf - )
-( cd $usepop/pop/lib/psv; tar cf - . ) | ( cd $usepop/pop/lib/psv-xt; tar xf - )
+mkdir -p "$usepop"/pop/pop-xt
+mkdir -p "$usepop"/pop/lib/psv-xt
+( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-xt; tar xf - )
+( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-xt; tar xf - )
 
 
 ### motif ######################################################################
 
 $usepop/pop/src/newpop -link -x=-xm -norsv
 
-echo_env "$usepop" > ${BUILD_HOME}/environments/xm
-echo_env "$usepop/pop/.." > ${BUILD_HOME}/environments/xm-cmp
-( cd ${BUILD_HOME}/environments && \
+echo_env "$usepop" > "${BUILD_HOME}/environments/xm"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/xm-cmp"
+( cd "${BUILD_HOME}/environments" && \
   sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-xm!g' < xm | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-xm/!g' > xm-new )
 
-mkdir -p $usepop/pop/pop-xm
-mkdir -p $usepop/pop/lib/psv-xm
-( cd $usepop/pop/pop; tar cf - . ) | ( cd $usepop/pop/pop-xm; tar xf - )
-( cd $usepop/pop/lib/psv; tar cf - . ) | ( cd $usepop/pop/lib/psv-xm; tar xf - )
+mkdir -p "$usepop"/pop/pop-xm
+mkdir -p "$usepop"/pop/lib/psv-xm
+( cd "$usepop"/pop/pop; tar cf - . ) | ( cd "$usepop"/pop/pop-xm; tar xf - )
+( cd "$usepop"/pop/lib/psv; tar cf - . ) | ( cd "$usepop"/pop/lib/psv-xm; tar xf - )
 
 
 ### nox ########################################################################
 
 $usepop/pop/src/newpop -link -nox -norsv
 
-echo_env "$usepop" > ${BUILD_HOME}/environments/nox
-echo_env "$usepop/pop/.." > ${BUILD_HOME}/environments/nox-cmp
-( cd ${BUILD_HOME}/environments && \
+echo_env "$usepop" > "${BUILD_HOME}/environments/nox"
+echo_env "$usepop/pop/.." > "${BUILD_HOME}/environments/nox-cmp"
+( cd "${BUILD_HOME}/environments" && \
   sed -e 's!\[//USEPOP//]/pop/pop![//USEPOP//]/pop/pop-nox!g' < nox | \
   sed -e 's!\[//USEPOP//]/pop/lib/psv/![//USEPOP//]/pop/lib/psv-nox/!g' > nox-new )
 
 # Rename rather than copy.
-mv $usepop/pop/pop $usepop/pop/pop-nox
-mv $usepop/pop/lib/psv $usepop/pop/lib/psv-nox
+mv "$usepop"/pop/pop "$usepop"/pop/pop-nox
+mv "$usepop"/pop/lib/psv "$usepop"/pop/lib/psv-nox
 
 ################################################################################
 
 # Choose our default build variant.
-ln -sf pop-nox $usepop/pop/pop
-ln -sf psv-nox $usepop/pop/lib/psv
+ln -sf pop-nox "$usepop/pop/pop"
+ln -sf psv-nox "$usepop/pop/lib/psv"

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -44,7 +44,12 @@ cd $usepop/pop/x/src/
 
 mkdir -p "${BUILD_HOME}/environments"
 
-# We need to capture the Poplog environment for each build variant.
+# We need to capture the Poplog environment for each build variant. This is
+# required for the poplog command tool, which needs to bind the appropriate 
+# environment variables. Each build variant has slightly different variables
+# and values. So we capture these and later on will synthesise them into 
+# C-code functions. This is the best point at which to capture the variables.
+
 # We run the popenv.sh script inside a clean environment to capture the 
 # set of environment variables needed. We then need to replace any matches
 # of the string "_build/poplog_base" ($usepop) with our unique value USEPOP.

--- a/makeSystemTools.sh
+++ b/makeSystemTools.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
 SEED_DIR=`pwd`
 
 # Run the initialisation files to set up additional environment

--- a/relinkCorepop.sh
+++ b/relinkCorepop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 POP_arch=x86_64


### PR DESCRIPTION
This is now the full set of changes for the 3-in-1 feature:

 - We build the three variants and create copies of their `$usepop/pop/pop` (aka `$popsys`) and `$usepop/pop/lib/psv` folders, as those contain the parts that vary.
 - Each variant potentially gets its own set of variables. These are separately captured in `_build/environments/`. This folder is utilized by makePoplogCommander.sh.
 - The poplog command tool is moved out of $popsys because it is not local to the build-variant and into `bin`.
 - The makePoplogCommander.sh script now runs in bash rather than sh as it is a pure build-time activity, allowing the `$(foo^^}` syntax.
    - struct Chain is now struct Vector, as 'chain' would be a better name for a linked list. That's a simple rename.
    - a new double-ended queue struct Deque is introduced.
    - The processing of an array of arguments (argv) is now replaced by processing a Deque (argd).
    - A new option --use-build is added and this is used to determine the correct variant to use.
    - The variant is encoded in the bitflags argument, which in retrospect looks a bit hacky.
    - The --help option is modified appropriately.

Note that the Motif build does not currently work, so the xt-variant is the default for interactive programming.

Also missing are any systests.