### PR TITLE
Make linking with Motif the default

### DIFF
--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -39,5 +39,6 @@ cd $usepop/pop/x/src/
 # ways to construct the Poplog system.
 # $usepop/pop/src/newpop -link -nox -norsv
 # $usepop/pop/src/newpop -link -x=-xm -norsv
-$usepop/pop/src/newpop -link -x=-xt -norsv
+# $usepop/pop/src/newpop -link -x=-xt -norsv
+$usepop/pop/src/newpop -link -x=-xm -norsv
 

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -27,6 +27,7 @@ Depends: ${misc:Depends},
  libx11-6,
  libxt-dev,
  libx11-dev,
+ libmotif-dev,
  libtinfo5
 Suggests: espeak, xterm, csh
 Description: Integrated development environment for POP-11, Common Lisp, Prolog and Standard ML.

--- a/packaging/rpm/poplog.spec.tmpl
+++ b/packaging/rpm/poplog.spec.tmpl
@@ -38,6 +38,7 @@ Requires: glibc(x86-32)
 # libXt-devel is needed for some reason, without it libXt.so load errors occur.
 Requires: libXt-devel
 Requires: openmotif
+Requires: openmotif-devel
 # See comments on conditional BuildRequires for information on
 # which packages are selected for different distributions
 %if 0%{?rhel} && 0%{?rhel} < 8


### PR DESCRIPTION
It will take a little while to get the 3-in-1 pull request past review. In the interim we can make Poplog with Motif the default.