### PR TITLE
Spike - switching over to --no-gui & --gui

### DIFF
--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -12,8 +12,15 @@ set -euo pipefail
 # DEFAULT_RUN_VARIANT is the default for scripts.
 ################################################################################
 
-VARIANT_BUILDS=(nox xt xm)
+# The options are what the user types. They have to be translated into builds.
+# e.g. --gui=xt has to become xt. The reason for that is that the 'editions'
+# of Poplog relate to the mutually exclusive build options. The mapping is 
+# implicitly defined by matching position in the two (congruent) arrays.
 VARIANT_OPTIONS=(--no-gui --gui=xt --gui=motif)
+VARIANT_BUILDS=(nox xt xm)
+
+# And the defaults are defined in terms of builds rather than options. That is
+# because they are entirely internal constants.
 DEFAULT_DEV_VARIANT=xm
 DEFAULT_RUN_VARIANT=nox
 

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 # implicitly defined by matching position in the two (congruent) arrays.
 VARIANT_OPTIONS=(--no-gui --gui=xt --gui=motif)
 VARIANT_BUILDS=(nox xt xm)
+# Sanity check
+[[ ${#VARIANT_OPTIONS[@]} -eq ${#VARIANT_BUILDS[@]} ]] || { echo "VARIANT_OPTIONS should have the same number of items as VARIANT_BUILDS but did not"; exit 1; }
 
 # And the defaults are defined in terms of builds rather than options. That is
 # because they are entirely internal constants.
@@ -857,7 +859,7 @@ cat << \****
             if ( 0 ) {
                 // Never taken - a trick to regularise the following cases.
 ****
-for n in {0..2}
+for ((n=0; n<${#VARIANT_OPTIONS[@]}; n++)) do
 do
     option="${VARIANT_OPTIONS[n]}"
     build="${VARIANT_BUILDS[n]}"

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -859,7 +859,7 @@ cat << \****
             if ( 0 ) {
                 // Never taken - a trick to regularise the following cases.
 ****
-for ((n=0; n<${#VARIANT_OPTIONS[@]}; n++)) do
+for ((n=0; n<${#VARIANT_OPTIONS[@]}; n++))
 do
     option="${VARIANT_OPTIONS[n]}"
     build="${VARIANT_BUILDS[n]}"


### PR DESCRIPTION
This is an exploration of the way in which we can switch from --use-build to --no-gui, --gui. N.B. The base branch is not main but the part1 branch. If/when we complete this pull-request we will fold it back into the part1 branch and carry on with the review process there.