### PR TITLE
Escape newlines in the environment.

### DIFF
--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -63,9 +63,17 @@ mkdir -p "${BUILD_HOME}/environments"
 # at run-time. 
 #
 
+# Note that we preserve newlines in the value of environment variables by
+# transforming them into C escape strings. We _also_ must escape backslashes
+# so that makePoplogCommander.sh can tell the difference between a newline
+# and a literal '\n'. Fortunately this is just enough. Any other C escaping
+# will be done on the makePoplogCommander.sh.
 echo_env() {
-    cmd='(usepop="'"$1"'" && . $usepop/pop/com/popenv.sh && env)'
+    cmd='(usepop="'"$1"'" && . $usepop/pop/com/popenv.sh && env -0)'
     env -i sh -c "$cmd" | \
+    sed -z -e 's/\\/\\\\/g' | \
+    sed -z -e 's/\n/\\n/g' | \
+    tr '\0' '\n' | \
     grep -v '^\(_\|SHLVL\|PWD\|poplib\|poplocal\(auto\|bin\)\?\)=' | \
     sed -e 's!'"$1"'![//USEPOP//]!g' | \
     sort


### PR DESCRIPTION
Although newlines in environment variables are a very unusual situation generally and will not arise for the Poplog environment variables at all, I have taken a shot at managing this situation. 

What this exposes is that there are quite a few unpleasant and unhandled possibilities for non-printing characters to cause mayhem. And this fix actually makes the situation slightly worse, because some transformation is done on the `makeStage2.sh` side and some on the `makePoplogCommander.sh` side, which is why I have isolated it in a separate spike.

At the moment I think it would be better to throw an error if any captured environment variable had a newline in it. If only I could work out a neat way of doing that! To do it more properly, I think I would reach for the Python3 monkey wrench and do everything, including the transformation to C-code in Python3.



