### PR TITLE
Motif builds are not correct

### DIFF
--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -868,7 +868,7 @@ cat << \****
             setUpEnvironment( base, flags, envv );
 ****
 
-echo '            printf( "Poplog command tool v'${GET_POPLOG_VERSION:-Undefined}'\\n" );'
+echo '            printf( "Poplog command tool v'${GETPOPLOG_VERSION:-Undefined}'\\n" );'
 
 cat << \****
 

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -131,7 +131,7 @@ mv "$usepop"/pop/lib/psv{,-xt}
 ################################################################################
 
 # Choose our default build variant. 
-ln -sf pop-xt "$usepop/pop/pop"
-ln -sf psv-xt "$usepop/pop/lib/psv"
+ln -sf pop-xm "$usepop/pop/pop"
+ln -sf psv-xm "$usepop/pop/lib/psv"
 
 ### End of file ################################################################

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -82,11 +82,9 @@ link_and_create_env() {
     # -norsv inhibits the building of rsvpop11 (an obsolete license-free distributable runtime)
     # -nox specifies basepop11 should not be linked with X-windows.
     # -x=xt/xm specifies basepop11 should not be linked with Xt or Motif.
-    if [[ "$build" = nox ]]; then
-        $usepop/pop/src/newpop -link -${build} -norsv
-    else
-        $usepop/pop/src/newpop -link -x=-${build} -norsv
-    fi
+    declare -A build_options=( [xm]=-x=-xm [xt]=-x=-xt [nox]=-nox )
+
+    $usepop/pop/src/newpop -link "${build_options[$build]}" -norsv
 
     # echo_env has weak strategy because it relies on being able to identify 
     # substitutions of $usepop. So we do it twice with a tiny variation and check

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -81,7 +81,7 @@ link_and_create_env() {
     # Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
     # -norsv inhibits the building of rsvpop11 (an obsolete license-free distributable runtime)
     # -${build} specifies basepop11 should not be linked with/without X-windows.
-    $usepop/pop/src/newpop -link -${build} -norsv
+    $usepop/pop/src/newpop -link -x=${build} -norsv
     
     # echo_env has weak strategy because it relies on being able to identify 
     # substitutions of $usepop. So we do it twice with a tiny variation and check

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 BUILD_HOME=`pwd`/_build
 usepop=`pwd`/_build/poplog_base
@@ -80,9 +80,14 @@ link_and_create_env() {
     # Newpop - see https://raw.githubusercontent.com/GetPoplog/Base/main/pop/help/newpop
     # Rebuilds $popsys: re-links basepop11, rebuild saved images and generate scripts.
     # -norsv inhibits the building of rsvpop11 (an obsolete license-free distributable runtime)
-    # -${build} specifies basepop11 should not be linked with/without X-windows.
-    $usepop/pop/src/newpop -link -x=${build} -norsv
-    
+    # -nox specifies basepop11 should not be linked with X-windows.
+    # -x=xt/xm specifies basepop11 should not be linked with Xt or Motif.
+    if [[ "$build" = nox ]]; then
+        $usepop/pop/src/newpop -link -${build} -norsv
+    else
+        $usepop/pop/src/newpop -link -x=-${build} -norsv
+    fi
+
     # echo_env has weak strategy because it relies on being able to identify 
     # substitutions of $usepop. So we do it twice with a tiny variation and check
     # the results are the same in order to improve robustness.


### PR DESCRIPTION
When the code was refactored, the `newpop` invocation got changed from
`-x=-xm` to `-xm` which is incorrect.
This change brings back the `-x=` prefix.