### PR TITLE
Rebuild neural libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,7 @@ _build/poplog_base/pop/com/poplogout.%: _download/poplogout.%
 _build/Packages.proxy: _download/packages-V$(MAJOR_VERSION).tar.bz2 _build/Base.proxy
 	(cd _build/poplog_base/pop; tar jxf "../../../$<")
 	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; for f in *.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
+	cd _build/poplog_base/pop/packages/neural/; mkdir -p bin/linux; for f in src/c/*.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	touch $@
 
 # This target ensures that we rebuild popc, poplink, poplibr on top of the fresh corepop.

--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ _build/poplog_base/pop/com/poplogout.%: _download/poplogout.%
 
 _build/Packages.proxy: _download/packages-V$(MAJOR_VERSION).tar.bz2 _build/Base.proxy
 	(cd _build/poplog_base/pop; tar jxf "../../../$<")
-	cd _build/poplog_base/pop/packages/popvision/; mkdir -p bin/linux; for f in lib/*.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
+	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; for f in *.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	cd _build/poplog_base/pop/packages/neural/; mkdir -p bin/linux; for f in src/c/*.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ _build/poplog_base/pop/com/poplogout.%: _download/poplogout.%
 
 _build/Packages.proxy: _download/packages-V$(MAJOR_VERSION).tar.bz2 _build/Base.proxy
 	(cd _build/poplog_base/pop; tar jxf "../../../$<")
-	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; for f in *.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
+	cd _build/poplog_base/pop/packages/popvision/; mkdir -p bin/linux; for f in lib/*.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	cd _build/poplog_base/pop/packages/neural/; mkdir -p bin/linux; for f in src/c/*.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	touch $@
 


### PR DESCRIPTION
- The neural libs come as 32bit binaries in the .tar.gz file. This rebuilds them as part of the build process.
- ~The popvision libs were put in `popvision/lib/bin/linux`, I've changed this to `popvision/bin/linux` as I believe this is where they go.~ I was mistaken, it seems Waldek must have made some changes to his fork so that the directory layout is more sane but we don't seem to have those changes.
