### PR TITLE
Fix popvision mlp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,7 @@ _build/poplog_base/pop/com/poplogout.%: _download/poplogout.%
 
 _build/Packages.proxy: _download/packages-V$(MAJOR_VERSION).tar.bz2 _build/Base.proxy
 	(cd _build/poplog_base/pop; tar jxf "../../../$<")
+	./patchPackages.sh
 	cd _build/poplog_base/pop/packages/popvision/lib; mkdir -p bin/linux; for f in *.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	touch $@
 

--- a/patchPackages.sh
+++ b/patchPackages.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s globstar
+
+[[ -d "_build/poplog_base/pop" ]] || {
+    echo "Must extract packages to build dir first";
+    exit 1
+}
+cd _build/poplog_base/pop
+for patch_file in ../../../patches/**/*.diff; do
+    patch -p0 < "$patch_file"
+done

--- a/patches/packages/popvision/mlp.diff
+++ b/patches/packages/popvision/mlp.diff
@@ -1,0 +1,10 @@
+--- packages/popvision/lib/mlp.p	2000-03-02 10:50:55.000000000 +0000
++++ packages/popvision/lib/mlp.p.old	2021-08-22 23:08:29.126257659 +0100
+@@ -89,7 +89,6 @@
+     (seed >> shift) /* -> s3 */;
+ enddefine;
+ 
+-defclass lconstant ushortvec :ushort;
+ lconstant seedvec = initushortvec(3),
+     shortbits = 2**SIZEOFTYPE(:ushort,:1) - 1;
+ 


### PR DESCRIPTION
Before fix:

```
Setpop
: uses popvision;
: uses mlp;

;;; MISHAP - idw: ILLEGAL DECLARATION OF WORD (missing ; after lvars?)
;;; INVOLVING:  ushortvec_key
;;; FILE     :  /usr/local/poplog/V16/pop/packages/lib/../popvision/lib/mlp.p
;;;       LINE NUMBER:  93
;;; PRINT DOING
;;; DOING    :  defclass section loadlib do_load uses_lib_idents pop_setpop_co
;;;     mpiler
```

After fix:
```
Setpop
: uses popvision;
: uses mlp;
:
```