### PR TITLE
Add libpop build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,9 +413,17 @@ _build/Packages.proxy: _download/packages-V$(MAJOR_VERSION).tar.bz2 _build/Base.
 	cd _build/poplog_base/pop/packages/neural/; mkdir -p bin/linux; for f in src/c/*.c; do gcc -o bin/linux/`basename $$f .c`.so -O3 -fpic -shared $$f; done
 	touch $@
 
+LIBPOP_SRC:=$(wildcard base/pop/extern/lib/*.[ch])
+LIBPOP_OBJ:=$(filter %.o,$(LIBPOP_SRC:base/%.c=_build/poplog_base/%.o))
+LIBPOP:=_build/poplog_base/pop/extern/libpop.a
+$(LIBPOP_OBJ): _build/poplog_base/%.o: base/%.c
+	$(CC) -c -O $(CFLAGS) -o $@ $<
+$(LIBPOP): $(LIBPOP_OBJ)
+	$(AR) rc $@ $^
+
 # This target ensures that we rebuild popc, poplink, poplibr on top of the fresh corepop.
 # It is effectively Waldek's build_pop2 script.
-_build/Stage2.proxy: _build/Stage1.proxy _build/Newpop.proxy
+_build/Stage2.proxy: _build/Stage1.proxy _build/Newpop.proxy $(LIBPOP)
 	bash makeSystemTools.sh
 	bash makeStage2.sh
 	touch $@

--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -10,10 +10,6 @@ export usepop
 : "${popexternlib:?}"
 : "${popcom:?}"
 
-# echo "mklibpop"
-cd "$popexternlib"
-    ./mklibpop
-
 # mkXpw"
 cd "$popcom"
     ./mkXpw -I/usr/include/X11


### PR DESCRIPTION
`libpop.a` is built from a bunch of C files which don't need to be built multiple times, thus we might as well properly do the build, rather than use the bash-based `mklibpop` script.

You'll note that the header dependencies are a bit over the top, but better than not tracking them at all.
A better approach that should be taken in future is to make Makfiles for each target object and include these. A good description of this approach is here: https://news.ycombinator.com/item?id=15060207
(note this is a simpler version than that proposed in the Make manual which has some awful sed trickery and double expansion: https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html)