### PR TITLE
Add libXpw.so build target

### DIFF
--- a/makeStage2.sh
+++ b/makeStage2.sh
@@ -10,10 +10,6 @@ export usepop
 : "${popexternlib:?}"
 : "${popcom:?}"
 
-# mkXpw"
-cd "$popcom"
-    ./mkXpw -I/usr/include/X11
-
 cd "$usepop/pop/obj"
     # saving library files in old
     mkdir -p old


### PR DESCRIPTION
This is another target that is built unconditionally via invoking `mkXpw` in `makeStage2.sh`. We can simply build this once.

This PR builds on top of #112  and fixes up a bit of that code (didn't have header dependencies).