### PR TITLE
Run tests on local poplog build rather than using the system poplog

### DIFF
--- a/systests/common.py
+++ b/systests/common.py
@@ -7,8 +7,13 @@ from pathlib import Path
 from typing import List, Union
 
 
-POPLOG_BINARY_PATH = shutil.which("poplog")
 HERE = Path(__file__).absolute().parent
+BUILT_POPLOG_BINARY_PATH = Path(HERE.parent / "_build/poplog_base/pop/bin/poplog")
+USE_SYSTEM_POPLOG = os.getenv('USE_SYSTEM_POPLOG', '0')
+if BUILT_POPLOG_BINARY_PATH.exists() and USE_SYSTEM_POPLOG.lower() in {"0", "false"}:
+    POPLOG_BINARY_PATH = BUILT_POPLOG_BINARY_PATH
+else:
+    POPLOG_BINARY_PATH = shutil.which("poplog")
 
 
 def run_poplog_commander(args: Union[str, List[str]], extra_env=None) -> subprocess.CompletedProcess:

--- a/systests/test_poplog_commander.py
+++ b/systests/test_poplog_commander.py
@@ -55,7 +55,7 @@ class TestVariables:
         assert check_poplog_commander(
             ["--run", "pop11", ":systranslate('popcom')=>"],
             extra_env={"popcom": "/nosuchfile"},
-        ).endswith("poplog/V16/pop/com")
+        ).endswith("/pop/com")
 
     def test_conflicting_environment_variables_are_not_overwritten_in_pop11_environment_in_dev_mode(self):
         assert check_poplog_commander(


### PR DESCRIPTION
By default the tests use `which poplog` to determine which poplog to invoke. Now this is acceptable if you run `PATH=_build/poplog_base/pop/bin:$PATH pytest systests` so that the tests will use the local build, however this is a pain to run yourself each time.
Instead, it'd be better if we default to testing the built poplog--this is more inline with developer expectations.
This commit implements this behaviour, and allows overriding by specifying a `USE_SYSTEM_POPLOG` env var whose value, when anything other than `0` or a case-insensitive `false`, will cause the tests to use the system poplog determined via `which poplog`.