### PR TITLE
A series of Bigint arithmetic fixes copied from Waldek Heibsch, Closes #120

### DIFF
--- a/base/pop/src/bigint.p
+++ b/base/pop/src/bigint.p
@@ -366,14 +366,14 @@ define lconstant Bgi_*(x, y);
         _bgi_mult_add(_Yaddr!(SL)++ -> _Yaddr, _Xstart, _Xlen, _Raddr);
     endwhile;
 
+    if need_neg then
+        Bigint_negate_range(result@BGI_SLICES, result!BGI_LENGTH,
+                            result@BGI_SLICES)
+    endif;
+
     ;;; end of NO GC section
 
-    Bigint_return(result) -> Get_store() -> result;
-    if need_neg then
-        Bgi_negate(result);
-    else
-        result;
-    endif;
+    Bigint_return(result) -> Get_store();
 enddefine;
 
 

--- a/base/pop/src/bigint.p
+++ b/base/pop/src/bigint.p
@@ -144,7 +144,9 @@ define Bigint_return(bint);
             ;;; single must fit
             return(_pint(_x), bint)
         endif;
-        _shift(_x, _:SLICE_BITS) _biset (_addr--!(SL) -> _addr) -> _x;
+        bint@BGI_SLICES -> _addr;
+        _shift(_addr!(-SL)[_1], _:SLICE_BITS)
+        _biset(_addr!(SL)[_0]) -> _x;
 #_ENDIF
         ;;; see whether the resulting int fits into a popint
         if _pint_testovf(_x) then

--- a/base/pop/src/bigint_divide.p
+++ b/base/pop/src/bigint_divide.p
@@ -197,18 +197,12 @@ define lconstant Bgi_qrem(dd, dr, _want_quot);
     dd -> org_dd;                   ;;; save orginal dividend
     dd!BGI_LENGTH _add _1 -> _ddlen;
     if Bigint_neg(dd) then          ;;; dividend with extra 0 slice
-        Get_bigint(_ddlen _add _1) -> dd;       ;;; allow 1 more for overflow
+        Get_bigint(_ddlen) -> dd;
         org_dd@BGI_SLICES -> _addr;
         Bigint_negate_range(_addr, _ddlen _sub _1, dd@BGI_SLICES);
-        if dd!BGI_SLICES[_ddlen _sub _1] /== _0 then
-            ;;; overflowed, extend by 0
-            _0 -> dd!BGI_SLICES[_ddlen];
-            _ddlen _add _1 -> _ddlen
-        else
-            ;;; didn't overflow, can truncate
-            _ddlen -> dd!BGI_LENGTH;
-            dd@V_WORDS[_ddlen|SL.r]@~POPBASE -> Get_store()
-        endif;
+        ;;; extend by 0.  Due to added zero slice we can ignore
+        ;;; possible overflow
+        _0 -> dd!BGI_SLICES[_ddlen _sub _1];
         true ->> _negrem -> _negquot
     else
         Bigint_copy_len(dd, _ddlen) -> dd;

--- a/base/pop/src/bigint_divide.p
+++ b/base/pop/src/bigint_divide.p
@@ -217,8 +217,10 @@ define lconstant Bgi_qrem(dd, dr, _want_quot);
     endif;
     dr!BGI_LENGTH -> _drlen;
 
-    ;;; unless divisor now shorter than dividend, quotient is 0
-    if _drlen _greq _ddlen then
+    ;;; if dividend is smaller than divisor, quotient is 0
+    if _drlen _greq _ddlen or (_ddlen _sub _1 _eq _drlen
+          and (dd@BGI_SLICES)!(SL)[_ddlen _sub _2]
+               _lt dr!BGI_SLICES[_drlen _sub _1]) then
         ;;; remainder=dividend, quotient=0
         Clawback(0) -> ;            ;;; dummy to reclaim space used by copies
         return(Bigint_return(org_dd) ->, if _want_quot then 0 endif)

--- a/base/pop/src/bigint_shift.p
+++ b/base/pop/src/bigint_shift.p
@@ -53,7 +53,7 @@ define Bigint_<<(x, _nbits);
     _0 -> left_carry;                       ;;; initial left carry is 0
 
     repeat
-        _Xaddr!(SL)++ -> _Xaddr -> x;
+        _Xaddr!(-SL)++ -> _Xaddr -> x;
         _shift(x, _nbits) _biset left_carry
                                 -> _Raddr!(SL)++ -> _Raddr;
         quitunless(_Xaddr <@(SL) _Xlim);

--- a/systests/test_pop11.py
+++ b/systests/test_pop11.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from common import run_pop11_program
 
 class TestPop11:
+
     def test_hello_world(self):
         assert run_pop11_program("'hello world' =>") == "** hello world"
 
@@ -19,3 +20,43 @@ class TestPop11:
         nfib( 15 ) =>
         """)
         assert run_pop11_program(nfib_src) == "** 1973"
+
+    def test_updateof_testbit(self):
+        assert (
+            run_pop11_program( "true -> testbit( 30693733391817156297112049438, 95 ) =>" ) == 
+            f"** {(1 << 95) | 30693733391817156297112049438}"
+        )
+        assert (
+            run_pop11_program("true -> testbit( 5110700429819126684, 63 ) =>") == 
+            f"** {(1 << 63) | 5110700429819126684}"
+        )
+        assert (
+            run_pop11_program("true -> testbit( 2309579545893710632583768152453332180599682146927526616900307024944, 223 ) =>") == 
+            f"** {(1 << 223) | 2309579545893710632583768152453332180599682146927526616900307024944}"
+        )
+
+    def test_bigint_rem(self):
+        cmd = """2357947691 rem 100000000000000006579 =>"""
+        assert (
+            run_pop11_program(cmd) == 
+            f"** {2357947691 % 100000000000000006579}"
+        )
+
+    def test_gcd(self):
+        cmd = (
+            """
+            vars a = -1169201309864722334558986458047313198845068836864;
+            vars b = 531266229322835086541;
+            gcd_n(a, b, 2), a // b =>
+            """
+        )
+        assert (
+            run_pop11_program(cmd) == 
+            f"** 1 -446001278937690371636 -2200782292062898266479046908"
+        )
+
+    def test_left_shift(self):
+        assert (
+            run_pop11_program("-1490116119384765625 << 2 =>") == 
+            f"** {-1490116119384765625 << 2}"
+        )


### PR DESCRIPTION
Waldek noticed a series issues in the bigint libraries and corrected them in his repository. This PR copies across the commit messages and content to ease comparison. A single minor whitespace change has been made from Waldek's commits but line numbers have been preserved to reduce divergence.

The original commits were:

* [Fix bigint left shift of negative numbers](https://github.com/hebisch/poplog/commit/a6bc193380ce8016abf35680f4937db0f005974c)
* [Fix returning pop integers from bigint functions](https://github.com/hebisch/poplog/commit/7a1f801af5eebcae0c28246ddf9cf7e13ce0fe49)
* [Do not use uninitialized memory during bigint divide](https://github.com/hebisch/poplog/commit/625ca6b90fe4090656369fa8980c6472d93c9240)
* [Use safer way to return result of bigint multiplication](https://github.com/hebisch/poplog/commit/b87b3d5f8cd0d17ffc1795815d4c97abcc6623b9)
* [Discover more cases of 0 quotient in bigint divide](https://github.com/hebisch/poplog/commit/4e68d541367f1b83720bd357a8cade8405daf76e)

A further commit has been added that resolved issues in the function `testbit`.

IMPORTANT NOTE: Ideally we will include unit tests with this PR but this is submitted now in order to begin the review process.