### PR TITLE
Feature/popc quiet flag, closing #126

### DIFF
--- a/base/pop/help/popc
+++ b/base/pop/help/popc
@@ -254,6 +254,10 @@ searched, i.e. disables the use of popsyslist.
             Produce output files in  directory (can occur anywhere,  and
             affects all following source files).
 
+    -quiet
+            Suppresses the popgctrace messages and inhibits the printing 
+            of multiple file names when compiling multiple files.
+
     -u arg-list
             Use Pop-11  source  libraries:  for each  arg  in  arg-list,
             compiles

--- a/base/pop/src/syscomp/popc_main.p
+++ b/base/pop/src/syscomp/popc_main.p
@@ -1671,7 +1671,7 @@ define $-Pop$-Main();
                 elseif c == "l" then
                     ;;; list names of files compiled (now done
                     ;;; automatically for more than 1 file). Explicitly
-                    ;;; removes -q if previously set.
+                    ;;; clears -q_flag- if previously set.
                     true -> l_flag;
                     false -> q_flag;
 
@@ -1772,7 +1772,7 @@ define $-Pop$-Main();
         false -> l_flag;
         false -> popgctrace;
     elseif n_compile > 1 then
-        ;;; If -q not set l_flag allowed to stand. And apply this default rule.
+        ;;; If q_flag not set l_flag allowed to stand. And apply this default rule.
         true -> l_flag;
     endif;
 

--- a/base/pop/src/syscomp/popc_main.p
+++ b/base/pop/src/syscomp/popc_main.p
@@ -1516,6 +1516,7 @@ lconstant procedure poplink_nf_options = newassoc([
 
     ]);
 
+vars procedure cucharverbose;
 
 define $-Pop$-Main();
     lvars   c, arg, dev, n,
@@ -1541,6 +1542,7 @@ define $-Pop$-Main();
             pop_file_versions = use_file_versions(),
             cucharout = cucharerr,
             % file_create_control(dlocal_context) %,
+            cucharverbose = cucharerr,
         ;
 
 #_IF pop_debugging
@@ -1698,6 +1700,10 @@ define $-Pop$-Main();
                     ;;; no system libraries
                     false -> syslib
 
+                elseif c == "quiet" then
+                    false -> popgctrace;
+                    erase -> cucharverbose;
+
                 elseif c == "u" then
                     ;;; use things
                     pop11_compile(stringin(consstring(#|
@@ -1810,7 +1816,7 @@ define $-Pop$-Main();
 
         define lconstant pr_fname(fname);
             lvars fname;
-            dlocal cucharout = cucharerr;
+            dlocal cucharout = cucharverbose;
             returnunless(l_flag);
 
             printf(fname, if len == 1 then

--- a/mk_recipes/buildInplace.mk
+++ b/mk_recipes/buildInplace.mk
@@ -112,7 +112,7 @@ SRC_WLB:=$(popobjlib)/src.wlb
 .proxy-wlb-objects: $(SRC_WLB_SRC) $(SRC_WLB_HEADERS) $(POPC)
 	cd $(popsrc)
 	rm -f $@
-	$(RUN_POPC) -c -nosys $(POP_ARCH)/*.[ps] ./*.p
+	$(RUN_POPC) -quiet -c -nosys $(POP_ARCH)/*.[ps] ./*.p
 	touch "$@"
 
 $(SRC_WLB): .proxy-wlb-objects $(POPLIBR)
@@ -133,7 +133,7 @@ VED_WLB:=$(popobjlib)/vedsrc.wlb
 .proxy-ved-wlb-objects : $(VED_WLB_SRC) $(VED_WLB_HEADERS) $(POPC)
 	cd $(usepop)/pop/ved/src
 	rm -f $@
-	$(RUN_POPC) -c -nosys -wlib \( ../../src/ \) ./*.p
+	$(RUN_POPC) -quiet -c -nosys -wlib \( ../../src/ \) ./*.p
 	touch "$@"
 
 $(VED_WLB): $(popobjlib)/src.wlb .proxy-ved-wlb-objects $(POPLIBR)
@@ -171,7 +171,7 @@ XSRC_WLB:=$(popobjlib)/xsrc.wlb
 .proxy-xsrc-wlb-objects: $(XSRC_WLB_SRC) $(XSRC_WLB_HEADERS) $(XPW_TARGET) $(POPC)
 	cd $(usepop)/pop/x/src
 	rm -f $@
-	$(RUN_POPC) -c -nosys -wlib \( ../../src/ \) ./*.p
+	$(RUN_POPC) -quiet -c -nosys -wlib \( ../../src/ \) ./*.p
 	touch "$@"
 
 $(XSRC_WLB): $(popobjlib)/src.wlb .proxy-xsrc-wlb-objects $(POPLIBR)


### PR DESCRIPTION
This adds a new flag '-quiet' to the popc compiler that suppresses the garbage collection message and also the printing of file names to stderr.