### PR TITLE
Feature/quiet image building

### DIFF
--- a/base/pop/help/mkimage
+++ b/base/pop/help/mkimage
@@ -299,6 +299,10 @@ should precede the image name.
     "undef"). (Has no affect on the value of pop_debugging when the
     saved image is restored.)
 
+-quiet
+    Reduces the amount of output produced by turning off popgctrace
+    and the file loading messages.
+
 -flags key flags
     LIB * MKIMAGE defines a property named mkimage_flags_table. This
     option adds to the table a mapping from the word key to a list of

--- a/base/pop/help/popc
+++ b/base/pop/help/popc
@@ -254,6 +254,10 @@ searched, i.e. disables the use of popsyslist.
             Produce output files in  directory (can occur anywhere,  and
             affects all following source files).
 
+    -quiet
+            Suppresses the popgctrace messages and inhibits the printing 
+            of multiple file names when compiling multiple files.
+
     -u arg-list
             Use Pop-11  source  libraries:  for each  arg  in  arg-list,
             compiles

--- a/base/pop/lib/lib/mkimage.p
+++ b/base/pop/lib/lib/mkimage.p
@@ -110,7 +110,9 @@ enddefine;
 define lconstant mkimage(args);
     lvars   arg, args, image, ss = false, initialisers = [], share = undef,
             nonwrit = false, vedmode = false, entry_p = false;
-    dlocal  pop_debugging = "undef";
+    dlocal  pop_debugging = "undef",
+            loadwarning,
+            libwarning;
 
     ;;; process any leading options (prefixed with '-')
     while args /== [] and isstartstring('-', hd(args)) do
@@ -157,6 +159,9 @@ define lconstant mkimage(args);
             false -> pop_debugging;
         elseif arg = '-debug' then
             true -> pop_debugging;
+        elseif arg = '-quiet' then
+            erase -> loadwarning;
+            erase -> libwarning;
         elseif arg = '-entrymain' or arg = '-entry' then
             if arg = '-entrymain' then
                 '$-Pop$-Main'

--- a/base/pop/lisp/src/clisp.p
+++ b/base/pop/lisp/src/clisp.p
@@ -14,6 +14,10 @@ sysflush(popdevout, true);
 sysgarbage();
 max(popmemused + 8e5, popmemlim) -> popmemlim;
 
+#_IF not(DEF lisp_debugging)
+vars lisp_debugging = false;
+#_ENDIF
+
 
 /********************** Initialise a few things *****************************/
 
@@ -41,9 +45,11 @@ define global lisp_src_compile(file);
     dlocal
         lisp_system_building    =   true,
         pop_debugging           =   false,
-        popgctrace              =   true,
+        popgctrace              =   lisp_debugging and true,
         popsyscall              =   1,
-        subsystem_compile_warn  =   sysloadwarning,
+        subsystem_compile_warn  =   lisp_debugging and sysloadwarning or erase,
+        loadwarning             =   lisp_debugging and sysloadwarning or erase,
+        libwarning              =   lisp_debugging and syslibwarning or erase,
         pop_buffer_charout      =   false,
         ;
     if islist(file) then

--- a/base/pop/plog/src/prolog.p
+++ b/base/pop/plog/src/prolog.p
@@ -202,7 +202,7 @@ define lconstant loadfile(file);
         prolog_no_clauses   = not(prolog_debugging),
         prolog_tags         = prolog_debugging,
         pop_debugging       = prolog_debugging,
-        popgctrace          = true,
+        popgctrace          = prolog_debugging and 1,
 
         ;;; Make backslash an alphabeticiser
         % item_chartype(`\\`) % = 12

--- a/base/pop/pml/src/ml.p
+++ b/base/pop/pml/src/ml.p
@@ -92,7 +92,7 @@ lvars warnings = false;
 define lconstant loadfile(file);
     lvars   dir, file, dev = false;
     dlocal  pop_debugging = ml_debugging,
-            popgctrace = true;
+            popgctrace = ml_debugging and true;
 
     ;;; Make backslash an alphabeticiser
     dlocal  % item_chartype(`\\`) % = 12;

--- a/base/pop/src/syscomp/popc_main.p
+++ b/base/pop/src/syscomp/popc_main.p
@@ -1671,7 +1671,7 @@ define $-Pop$-Main();
                 elseif c == "l" then
                     ;;; list names of files compiled (now done
                     ;;; automatically for more than 1 file). Explicitly
-                    ;;; removes -q if previously set.
+                    ;;; clears -q_flag- if previously set.
                     true -> l_flag;
                     false -> q_flag;
 
@@ -1772,7 +1772,7 @@ define $-Pop$-Main();
         false -> l_flag;
         false -> popgctrace;
     elseif n_compile > 1 then
-        ;;; If -q not set l_flag allowed to stand. And apply this default rule.
+        ;;; If q_flag not set l_flag allowed to stand. And apply this default rule.
         true -> l_flag;
     endif;
 

--- a/base/pop/src/syscomp/popc_main.p
+++ b/base/pop/src/syscomp/popc_main.p
@@ -1516,6 +1516,7 @@ lconstant procedure poplink_nf_options = newassoc([
 
     ]);
 
+vars procedure cucharverbose;
 
 define $-Pop$-Main();
     lvars   c, arg, dev, n,
@@ -1541,6 +1542,7 @@ define $-Pop$-Main();
             pop_file_versions = use_file_versions(),
             cucharout = cucharerr,
             % file_create_control(dlocal_context) %,
+            cucharverbose = cucharerr,
         ;
 
 #_IF pop_debugging
@@ -1698,6 +1700,10 @@ define $-Pop$-Main();
                     ;;; no system libraries
                     false -> syslib
 
+                elseif c == "quiet" then
+                    false -> popgctrace;
+                    erase -> cucharverbose;
+
                 elseif c == "u" then
                     ;;; use things
                     pop11_compile(stringin(consstring(#|
@@ -1810,7 +1816,7 @@ define $-Pop$-Main();
 
         define lconstant pr_fname(fname);
             lvars fname;
-            dlocal cucharout = cucharerr;
+            dlocal cucharout = cucharverbose;
             returnunless(l_flag);
 
             printf(fname, if len == 1 then

--- a/mk_recipes/buildInplace.mk
+++ b/mk_recipes/buildInplace.mk
@@ -84,7 +84,7 @@ POP_COMPILER_TOOLS:=$(POPC) $(POPLIBR) $(POPLINK)
 	export POP__as
 	cd $(popsrc)
 	rm -f ./{popc,poplibr,poplink}.psv*
-	$(MK_CROSS) -d -a=$(POP_ARCH) popc poplibr poplink
+	$(MK_CROSS) -a=$(POP_ARCH) popc poplibr poplink
 	touch "$@"
 
 $(POPLINK): .proxy-pop-compiler-tool-images $(COREPOP)

--- a/mk_recipes/buildInplace.mk
+++ b/mk_recipes/buildInplace.mk
@@ -224,25 +224,25 @@ BASEPOPS:=$(addprefix $(popsys)/,pop11 basepop11 basepop11.stb basepop11.map)
 $(popsavelib)/startup.psv: .proxy-basepops
 	source $(popcom)/popinit.sh
 	cd $(popsys)
-	./basepop11 %nort %noinit ../lib/lib/mkimage.p -nodebug -nonwriteable -install $@ startup
+	./basepop11 %nort %noinit ../lib/lib/mkimage.p -quiet -nodebug -nonwriteable -install $@ startup
 
 $(popsavelib)/clisp.psv: .proxy-basepops $(popsavelib)/startup.psv $(popsys)/popenv.sh
 	@rm -f $@
 	cd $(popsys)
 	ln -f basepop11 clisp
-	$(RUN_MKIMAGE) -install -subsystem lisp $@ ../lisp/src/clisp.p
+	$(RUN_MKIMAGE) -quiet -install -subsystem lisp $@ ../lisp/src/clisp.p
 
 $(popsavelib)/prolog.psv: .proxy-basepops $(popsavelib)/startup.psv $(popsys)/popenv.sh
 	@rm -f $@
 	cd $(popsys)
 	ln -f basepop11 prolog
-	$(RUN_MKIMAGE) -nodebug -install -flags prolog \( \) $@ ../plog/src/prolog.p
+	$(RUN_MKIMAGE) -quiet -nodebug -install -flags prolog \( \) $@ ../plog/src/prolog.p
 
 $(popsavelib)/pml.psv: .proxy-basepops $(popsavelib)/startup.psv $(popsys)/popenv.sh
 	@rm -f $@
 	cd $(popsys)
 	ln -f basepop11 pml
-	$(RUN_MKIMAGE) -nodebug -install -flags ml \( \) $@ ../pml/src/ml.p
+	$(RUN_MKIMAGE) -quiet -nodebug -install -flags ml \( \) $@ ../pml/src/ml.p
 
 .PHONY: images
 images: $(addsuffix .psv,$(addprefix $(popsavelib)/,startup clisp prolog pml))
@@ -252,7 +252,7 @@ $(popsavelib)/xved.psv: .proxy-basepops $(popsavelib)/startup.psv $(popsys)/pope
 	@rm -f $@
 	cd $(popsys)
 	ln -f basepop11 xved
-	$(RUN_MKIMAGE) -nodebug -nonwriteable -install -entry xved_standalone_setup $@ mkxved
+	$(RUN_MKIMAGE) -quiet -nodebug -nonwriteable -install -entry xved_standalone_setup $@ mkxved
 images: $(popsavelib)/xved.psv
 endif
 

--- a/mk_recipes/buildInplace.mk
+++ b/mk_recipes/buildInplace.mk
@@ -112,7 +112,7 @@ SRC_WLB:=$(popobjlib)/src.wlb
 .proxy-wlb-objects: $(SRC_WLB_SRC) $(SRC_WLB_HEADERS) $(POPC)
 	cd $(popsrc)
 	rm -f $@
-	$(RUN_POPC) -c -nosys $(POP_ARCH)/*.[ps] ./*.p
+	$(RUN_POPC) -quiet -c -nosys $(POP_ARCH)/*.[ps] ./*.p
 	touch "$@"
 
 $(SRC_WLB): .proxy-wlb-objects $(POPLIBR)
@@ -133,7 +133,7 @@ VED_WLB:=$(popobjlib)/vedsrc.wlb
 .proxy-ved-wlb-objects : $(VED_WLB_SRC) $(VED_WLB_HEADERS) $(POPC)
 	cd $(usepop)/pop/ved/src
 	rm -f $@
-	$(RUN_POPC) -c -nosys -wlib \( ../../src/ \) ./*.p
+	$(RUN_POPC) -quiet -c -nosys -wlib \( ../../src/ \) ./*.p
 	touch "$@"
 
 $(VED_WLB): $(popobjlib)/src.wlb .proxy-ved-wlb-objects $(POPLIBR)
@@ -171,7 +171,7 @@ XSRC_WLB:=$(popobjlib)/xsrc.wlb
 .proxy-xsrc-wlb-objects: $(XSRC_WLB_SRC) $(XSRC_WLB_HEADERS) $(XPW_TARGET) $(POPC)
 	cd $(usepop)/pop/x/src
 	rm -f $@
-	$(RUN_POPC) -c -nosys -wlib \( ../../src/ \) ./*.p
+	$(RUN_POPC) -quiet -c -nosys -wlib \( ../../src/ \) ./*.p
 	touch "$@"
 
 $(XSRC_WLB): $(popobjlib)/src.wlb .proxy-xsrc-wlb-objects $(POPLIBR)


### PR DESCRIPTION
Reduces the amount of noise during the build process by:

 - Adding a -quiet flag to mkimage.p (and documenting it)
 - Adding a lisp_debugging flag to the Common Lisp subsystem, defaulting to false, that reduces chatter
 - Turning off chatter from the subsystems that respect the -d flag of the `mk_cross` script
 - Making the Prolog and ML subsystems respect pop_debugging with regard to noisiness
 
 Note: this builds on the `popc -quiet` flag branch