### PR TITLE
poplog findhelp --category=help --exact <topic>, closing #130

### DIFF
--- a/base/pop/getpoploglib/auto/$.p
+++ b/base/pop/getpoploglib/auto/$.p
@@ -1,0 +1,66 @@
+section dollar => $;
+
+;;; Initially tried with '$_' and hit a lot of problems with '$_{'.
+lconstant autoload_prefix = 'dollar_';
+lconstant autoload_class_suffix = '_key';
+
+;;; This procedure provides an extension mechanism for the $ITEM syntax.
+;;; It maps from 'items' from the Pop-11 itemizer (words, string, numbers)
+;;; or keys (word_key, string_key, number keys) into code-planting
+;;; procedures.
+
+define lconstant lookup( item );
+    if item.isword then
+        lvars w = consword( autoload_prefix <> item.word_string );
+        lvars wid = word_identifier( w, pop_section, true );
+        if wid then
+            wid.valof
+        else
+            if sys_autoload( w ) then
+                word_identifier( w, pop_section, true ).valof
+            else
+                false
+            endif
+        endif
+    else
+        lvars w = consword( autoload_prefix <> item.datakey.class_name.word_string <> autoload_class_suffix );
+        lvars wid = word_identifier( w, pop_section, true );
+        [try to autoload ^w] =>
+        if sys_autoload( w ) then
+            [ succeeded] =>
+            word_identifier( w, pop_section, true ).valof
+        else
+            false
+        endif;
+    endif
+enddefine;
+
+define lconstant is_viable_shell_variable( w );
+    returnif( w.datalength <= 0 )( false );
+    lvars w1 = subscrw( 1, w );
+    returnunless( w1.isalphacode or w1 == `_` )( false );
+    lvars i;
+    for i from 2 to w.datalength do
+        lvars ch = subscrw( i, w );
+        returnunless( ch.isalphacode or ch.isnumbercode or ch == `_` )( false )
+    endfor;
+    return( true )
+enddefine;
+
+define global syntax $ ;
+    lvars item = readitem();
+    if item.isword and item.is_viable_shell_variable then
+        sysPUSHQ( item.word_string );
+        sysCALL -> pop_expr_inst;
+        "systranslate" -> pop_expr_item;
+    else
+        lvars p = lookup( item );
+        if p then
+            p( item )
+        else
+            mishap( 'Unexpected item after $', [^item] )
+        endif
+    endif
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/allfirst.p
+++ b/base/pop/getpoploglib/auto/allfirst.p
@@ -1,0 +1,25 @@
+section;
+compile_mode :pop11 +strict;
+
+;;; get the first n elemenst from a list/vector
+define global allfirst( n, x ); lvars n, x;
+    if x.isvectorclass then
+        class_cons( x.datakey )(#|
+            lvars i, count;
+            for i with_index count in_vectorclass x do
+                quitif( count fi_> n );
+                i
+            endfor
+        |#)
+    elseif x.islist then
+        [% applynum( x, dest, n ).erase %]
+    elseif x.isword then
+        ;;; It is safe to call fast_word_string because allfirst
+        ;;; is update-free.
+        allfirst( n, x.fast_word_string ).consword
+    else
+        mishap( 'VECTORCLASS, LIST OR WORD NEEDED', [ ^x ] )
+    endif
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/alllast.p
+++ b/base/pop/getpoploglib/auto/alllast.p
@@ -1,0 +1,38 @@
+section;
+compile_mode :pop11 +strict;
+
+;;; get the first n elements from a list/vector
+define global alllast( n, x ); lvars n, x;
+    if x.isvectorclass then
+        lvars K = x.datakey;
+        lvars S = K.class_fast_subscr;
+        lvars L = x.datalength;
+        if L < fi_check( n, 0, false ) then
+            mishap( 'Too few elements', [^n ^x] )
+        endif;
+        class_cons( x.datakey )(#|
+            lvars i;
+            fast_for i from L - n + 1 to L do
+                S( i, x )
+            endfor
+        |#)
+    elseif x.islist then
+        lvars result;
+        erasenum(#|
+            if x.destlist >= n then
+                conslist( n ) -> result;
+            else
+                mishap( 'Too few elements', [^n ^x] )
+            endif
+        |#);
+        result;
+    elseif x.isword then
+        ;;; It is safe to call fast_word_string because alllast is
+        ;;; an update-free procedure.
+        alllast( n, x.fast_word_string ).consword
+    else
+        mishap( 'VECTORCLASS, LIST OR WORD NEEDED', [ ^x ] )
+    endif
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/destdict_keys.p
+++ b/base/pop/getpoploglib/auto/destdict_keys.p
@@ -1,0 +1,11 @@
+compile_mode :pop11 +strict;
+
+uses dict
+
+section $-dict => destdict_keys;
+
+define global constant procedure destdict_keys( dict );
+    dict.dict_keys.destvector
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/destdict_values.p
+++ b/base/pop/getpoploglib/auto/destdict_values.p
@@ -1,0 +1,11 @@
+compile_mode :pop11 +strict;
+
+uses dict
+
+section $-dict => destdict_values;
+
+define global constant procedure destdict_values( dict );
+    dict.dict_values.destvector
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/dict_concat.p
+++ b/base/pop/getpoploglib/auto/dict_concat.p
@@ -1,0 +1,58 @@
+compile_mode :pop11 +strict;
+
+uses dict
+
+section $-dict => dict_concat;
+
+define global constant procedure dict_concat( d1, d2 );
+    lvars ( d1keys, d1values, d1length ) = d1.destdict.dup.datalength;
+    lvars ( d2keys, d2values, d2length ) = d2.destdict.dup.datalength;
+    lvars plist, d1i = 1, d2i = 1;
+    [%
+        repeat
+            if d1i > d1length then
+                ;;; Accept all of the remaining d2 items.
+                lvars i;
+                for i from d2i to d2length do
+                    conspair( 
+                        subscrv( i, d2keys ),
+                        subscrv( i, d2values )
+                    )
+                endfor;
+                quitloop
+            elseif d2i > d2length then
+                ;;; Accept all of the remaining d1 items. 
+                lvars i;
+                for i from d2i to d1length do
+                    conspair(
+                        subscrv( i, d1keys ),
+                        subscrv( i, d1values )
+                    )
+                endfor;
+                quitloop
+            endif;
+            lvars d1item = subscrv( d1i, d1keys );
+            lvars d2item = subscrv( d2i, d2keys );
+            lvars cmp = alphabefore( d1item, d2item );
+            if cmp == true then
+                conspair( d1item, subscrv( d1i, d1values ) );
+                d1i fi_+ 1 -> d1i;
+            elseif cmp == 1 then
+                conspair( d2item, subscrv( d2i, d2values ) );
+                d1i fi_+ 1 -> d1i;
+                d2i fi_+ 1 -> d2i;
+            else
+                conspair( d2item, subscrv( d2i, d2values ) );
+                d2i fi_+ 1 -> d2i;
+            endif
+        endrepeat
+    %] -> plist;
+    lvars keys = {% applist( plist, front ) %};
+    lvars values = {% applist( plist, back ) %};
+    while plist.ispair do
+        sys_grbg_destpair( sys_grbg_destpair( plist ) -> plist ) -> (_, _); 
+    endwhile;
+    consdict( keys.dict_table, values );
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/dict_copy.p
+++ b/base/pop/getpoploglib/auto/dict_copy.p
@@ -1,0 +1,10 @@
+compile_mode :pop11 +strict;
+
+section dict => dict_copy;
+
+define global constant procedure dict_copy( dict );
+    lvars ( keys_vector, values_vector ) = dict.destdict;
+    consdict( keys_vector, values_vector.copy )
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/dict_dest.p
+++ b/base/pop/getpoploglib/auto/dict_dest.p
@@ -1,0 +1,9 @@
+compile_mode :pop11 +strict;
+
+section dict => dict_dest;
+
+define global constant procedure dict_dest( d );
+    (#| appdict( dict, identfn ) |#)
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/discinline.p
+++ b/base/pop/getpoploglib/auto/discinline.p
@@ -1,0 +1,41 @@
+;;; Summary: like discin <> incharline but more efficient
+
+compile_mode :pop11 +strict;
+
+section;
+
+uses sysstring;
+
+unless sysstringlen > 0 and sysstringlen.isinteger do
+    mishap( 'sysstring is too big (or small)', [length ^sysstringlen] )
+endunless;
+
+define global vars procedure discinline( file ); lvars file;
+    lvars dev = file.isdevice and file or sysopen( file, 0, "line" );
+    procedure();
+        lvars N = sysread( dev, sysstring, sysstringlen );
+        if N == 0 then
+            termin
+        elseif subscrs( N, sysstring ) == `\n` do
+            substring( 1, N fi_- 1, sysstring )
+        elseif N < sysstringlen then
+            substring( 1, N, sysstring )
+        else
+            consstring(#|
+                until N fi_< sysstringlen or subscrs( N, sysstring ) == `\n` do
+                    sysstring.deststring.erase;
+                    sysread( dev, sysstring, sysstringlen ) -> N;
+                enduntil;
+                lvars n;
+                fast_for n from 1 to N do
+                    fast_subscrs( n, sysstring )
+                endfor;
+                if dup() == `\n` then
+                    erase()
+                endif;
+            |#)
+        endif
+    endprocedure;
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/dollar_{.p
+++ b/base/pop/getpoploglib/auto/dollar_{.p
@@ -1,0 +1,19 @@
+compile_mode :pop11 +strict;
+
+section;
+
+;;; Idiom for 'silently load a lib defining a class if not loaded already'.
+unless isdeclared("dict_key") then
+    loadlib("dict")
+endunless;
+
+;;;
+;;; Pop-11 really does not like the identifier dollar_{ so we need to force
+;;; the assignment with some low-level code.
+;;;
+ident_declare( "'dollar_{'", "syntax", 0 );
+procedure(word) with_props 'dollar_{';
+    $-dict$-compile_newdict_to( "}" ) -> _;
+endprocedure -> idval( identof( "'dollar_{'" ) );
+
+endsection;

--- a/base/pop/getpoploglib/auto/extend_dict.p
+++ b/base/pop/getpoploglib/auto/extend_dict.p
@@ -1,0 +1,43 @@
+compile_mode :pop11 +strict;
+
+uses dict
+
+section dict => extend_dict;
+
+uses dict
+
+define global constant procedure extend_dict( name, value, dict );
+    lvars (keys_vector, values_vector) = destdict( dict );
+    lvars count = datalength( values_vector );
+    lvars n = find( name, dict, true );
+    if subscrv( n, keys_vector ) == name then
+        values_vector.copy -> values_vector;
+        value -> subscrv( n, values_vector );
+        consdict( keys_vector, values_vector )
+    elseif n == 0 then
+        newdict_internal( {^name ^^keys_vector}, {^value ^^values_vector} )
+    else
+        ;;; -n- is the numbers of keys that precedes -name-.
+        lvars new_keys_vector = {%
+            lvars i;
+            fast_for i from 1 to count do
+                subscrv( i, keys_vector );
+                if i == n then
+                    name
+                endif
+            endfast_for
+        %};
+        lvars new_values_vector = {%
+            lvars i;
+            fast_for i from 1 to count do
+                subscrv( i, values_vector );
+                if i == n then
+                    value
+                endif
+            endfast_for
+        %};
+        newdict_internal( new_keys_vector, new_values_vector )
+    endif
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
+++ b/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
@@ -2,66 +2,7 @@ compile_mode :pop11 +strict;
 
 /*  Generates a JSON dump of where help can be located in the Poplog file
     hierarchy. The JSON obeys the following schema:
-
-{
-  "$id": "https://github.com/GetPoplog/findhelp.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "FindHelp",
-  "type": "object",
-  "properties": {
-    "popversion": {
-      "description": "A string describing the version of Poplog.",
-      "type": "string"
-    },
-    "documentation": {
-      "description": "Matching documentation.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "quality": {
-            "description": "A number from 0 to 1.0 indicating the match quality, with 1 being a perfect match.",
-            "type": "number"
-          },
-          "category": {
-            "description": "The category of documentation, reflecting the level formality and technical detail.",
-            "type": "string",
-            "enum": [ "help", "teach", "doc", "ref" ]
-          },
-          "title": {
-            "description": "The title of the resource.",
-            "type": "string"
-          },
-          "summary": {
-            "description": "An optional summary of the resource as a list of lines, which may be null.",
-            "type": ["array", "null"],
-            "items": { "type": "string" }
-          },
-          "path": {
-            "description": "File path of the resource.",
-            "type": "string"
-          },
-          "from": {
-            "description": "Position in the file the description starts, which may be null.",
-            "type": ["integer", "null"]
-          },
-          "end": {
-            "description": "Position in the file of the last line of the description, which may be null.",
-            "type": ["integer", "null"]
-          },
-          "content": {
-            "description": "Full content as a list of lines, which may be null.",
-            "type": [ "array", "null" ],
-            "items": { "type": "string" }
-          }
-        },
-        "required": ["quality", "title", "summary", "path", "lineno", "category"]
-      }
-    },
-    "required": ["popversion", "documentation"]
-  }
-}
-
+        https://gist.github.com/sfkleach/4065ef69d393c659e297420ebc8c0248
 */
 
 section;

--- a/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
+++ b/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
@@ -146,7 +146,7 @@ define subcmd_findhelp( category, topic, exact );
             lvars m = syssearchpath( search_list, topic );
             if m then
                 lvars qc = category_match_quality( category, m(2) );
-                ${ quality=qc, category=m(2), title=topic, path=m(1), lineno=false, summary=false }
+                ${ quality=qc, category=m(2), title=topic, path=m(1), from=pop_undef, to=pop_undef, summary=pop_undef }
             else
                 false
             endif
@@ -174,14 +174,14 @@ define subcmd_findhelp( category, topic, exact );
                 lvars isummary = trim_summary( lines( L1 ) );
                 lvars qc = category_match_quality( category, icat );
                 lvars qt = topic_match_quality( topic, itopic );
-                ${ quality=qc*qt, category=icat, title=itopic, path=ipath, lineno=L1, summary=isummary }
+                ${ quality=qc*qt, category=icat, title=itopic, path=ipath, from=L1, to=L3, summary=isummary }
             endfor;
         endfor
     %];
     if exact_match then
         exact_match :: options -> options;
     endif;
-    nc_listsort( options, procedure( x, y ); x("quality") >= y("quality") endprocedure )
+    ${ popversion=popversion, documentation=nc_listsort( options, procedure( x, y ); x("quality") >= y("quality") endprocedure ) }
 enddefine;
 
 define getpoplog_subcommand_findhelp( options, args );

--- a/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
+++ b/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
@@ -169,7 +169,7 @@ define lconstant extend_with_content( option, procedure fetcher );
     extend_dict( "content", content, option )
 enddefine;
 
-define subcmd_findhelp( category, topic, exact, with_content );
+define subcmd_findhelp( category, topic, exact, with_content, maxmatches );
     lvars search_list = (
         if category == "help" then
             [vedhelplist]
@@ -226,15 +226,28 @@ define subcmd_findhelp( category, topic, exact, with_content );
     if exact_match then
         exact_match :: options -> options;
     endif;
+    nc_listsort( options, procedure( x, y ); x("quality") >= y("quality") endprocedure ) -> options;
+    if maxmatches and maxmatches > 0 and maxmatches < options.length then
+        allfirst( maxmatches, options ) -> options;
+    endif;
     if with_content then
         maplist( options, extend_with_content(%fetcher%) ) -> options
     endif;
-    ${ popversion=popversion, documentation=nc_listsort( options, procedure( x, y ); x("quality") >= y("quality") endprocedure ) }
+
+    ${ popversion=popversion, documentation=options }
 enddefine;
 
 define getpoplog_subcommand_findhelp( options, args );
-    dict_concat( ${ category='help', exact=false, content=false }, options ) -> options;
-    json_println( subcmd_findhelp( consword(options("category")), args(1), options("exact"), options("content") ) )
+    dict_concat( ${ category='help', exact=false, content=false, maxmatches=false }, options ) -> options;
+    json_println( 
+        subcmd_findhelp( 
+            consword(options("category")), 
+            args(1), 
+            options("exact"), 
+            options("content"),
+            strnumber( options("maxmatches") or '-1' )
+        ) 
+    )
 enddefine;
 
 endsection;

--- a/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
+++ b/base/pop/getpoploglib/auto/getpoplog_subcommand_findhelp.p
@@ -1,0 +1,192 @@
+compile_mode :pop11 +strict;
+
+/*  Generates a JSON dump of where help can be located in the Poplog file
+    hierarchy. The JSON obeys the following schema:
+
+{
+  "$id": "https://github.com/GetPoplog/findhelp.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FindHelp",
+  "type": "object",
+  "properties": {
+    "popversion": {
+      "description": "A string describing the version of Poplog.",
+      "type": "string"
+    },
+    "documentation": {
+      "description": "Matching documentation.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "quality": {
+            "description": "A number from 0 to 1.0 indicating the match quality, with 1 being a perfect match.",
+            "type": "number"
+          },
+          "category": {
+            "description": "The category of documentation, reflecting the level formality and technical detail.",
+            "type": "string",
+            "enum": [ "help", "teach", "doc", "ref" ]
+          },
+          "title": {
+            "description": "The title of the resource.",
+            "type": "string"
+          },
+          "summary": {
+            "description": "An optional summary of the resource, which may be null.",
+            "type": ["string", "null"]
+          },
+          "path": {
+            "description": "File path of the resource.",
+            "type": "string"
+          },
+          "lineno": {
+            "description": "Position in the file the description starts, which may be null.",
+            "type": ["integer", "null"]
+          }
+        },
+        "required": ["quality", "title", "summary", "path", "lineno", "category"],
+        "additionalProperties": false
+      }
+    },
+    "required": ["popversion", "documentation"],
+    "additionalProperties": false
+  }
+}
+
+*/
+
+section;
+
+uses getpoplog;
+uses dict;
+
+/*
+Design note:
+- For exact matches use syssearchpath e.g. syssearchpath( [vedhelplist], 'rev' )
+- For approximate matches use ved_??_search_doc_index e.g. ved_??_search_doc_index( 'rev', [vedhelplist] )
+*/
+
+
+define lconstant getline( path, line_no );
+    lvars lines = pdtolist( discinline( path ) );
+    return( lines( line_no ) );
+enddefine;
+
+define lconstant new_line_fetcher();
+    newanyproperty(
+        [], 8, 1, 7,
+        syshash, nonop =, "perm",
+        false,
+        procedure( path, self );
+            pdtolist( discinline( path ) ) ->> self( path )
+        endprocedure
+    );
+enddefine;
+
+define lconstant trim_summary( line ) -> line;
+    lvars i = locchar(`[`, 2, line);
+    if i then
+        skipchar_back(`\s`, i - 1, line) -> i;
+        substring(1, i, line) -> line
+    endif;
+enddefine;
+
+lconstant
+    CATEGORY_MISMATCH_PENALTY = 0.03,
+    TOPIC_SUFFIX_MISMATCH_PENALTY = 0.04,
+    TOPIC_PREFIX_MISMATCH_PENALTY = 0.05;
+
+define lconstant category_match_quality( expected, actual );
+    ;;; By coincidence the difference in length of names gives
+    ;;; a good heuristic! (That ref and teach are extra-different).
+    if expected == actual then
+        1.0
+    else
+        lvars n = abs( datalength( expected ) - datalength( actual ) );
+        (1.0 - CATEGORY_MISMATCH_PENALTY) ** n
+    endif
+enddefine;
+
+define lconstant topic_match_quality( expected, actual );
+    if expected == actual then
+        1.0
+    else
+        lvars n = issubstring( expected, actual );
+        if n then
+            lvars n1 = n - 1;
+            lvars pm = ( 1.0 - TOPIC_PREFIX_MISMATCH_PENALTY ) ** n1;
+            lvars n2 = datalength( actual ) - ( n1 + datalength( expected ) );
+            lvars sm = ( 1.0 - TOPIC_SUFFIX_MISMATCH_PENALTY ) ** n2;
+            pm * sm
+        else
+            ;;; Not supposed to happen!
+            0.0
+        endif
+    endif
+enddefine;
+
+define subcmd_findhelp( category, topic, exact );
+    lvars search_list = (
+        if category == "help" then
+            [vedhelplist]
+        elseif category == "teach" then
+            [vedteachlist]
+        elseif category == "doc" then
+            [veddoclist]
+        elseif category == "ref" then
+            [vedreflist]
+        else
+            [vedreflist]
+        endif
+    );
+
+    lvars exact_match =
+        lblock
+            lvars m = syssearchpath( search_list, topic );
+            if m then
+                lvars qc = category_match_quality( category, m(2) );
+                ${ quality=qc, category=m(2), title=topic, path=m(1), lineno=false, summary=false }
+            else
+                false
+            endif
+        endlblock;
+
+    returnif( exact )( exact_match and [ ^exact_match ] or [] );
+
+    lvars procedure fetcher = new_line_fetcher();
+    lvars ecat = exact_match and exact_match("category");
+    lvars etopic = exact_match and exact_match("title");
+    lvars epath = exact_match and exact_match("path");
+    lvars options = [%
+        lvars row;
+        for row in ved_??_search_doc_index( '*' <> topic <> '*', search_list ) do
+            lvars result;
+            for result in tl( row ) do
+                lvars icat = hd( row );
+                lvars ( itopic, apath, L1, L2, L3 ) = result.explode;
+                lvars ipath = sysfileok( apath );
+                if ipath = epath and icat == ecat and itopic = etopic then
+                    ;;; Supersedes exact_match.
+                    false -> exact_match
+                endif;
+                lvars lines = fetcher( ipath );
+                lvars isummary = trim_summary( lines( L1 ) );
+                lvars qc = category_match_quality( category, icat );
+                lvars qt = topic_match_quality( topic, itopic );
+                ${ quality=qc*qt, category=icat, title=itopic, path=ipath, lineno=L1, summary=isummary }
+            endfor;
+        endfor
+    %];
+    if exact_match then
+        exact_match :: options -> options;
+    endif;
+    nc_listsort( options, procedure( x, y ); x("quality") >= y("quality") endprocedure )
+enddefine;
+
+define getpoplog_subcommand_findhelp( options, args );
+    dict_concat( ${ category='help', exact=false }, options ) -> options;
+    json_println( subcmd_findhelp( consword(options("category")), args(1), options("exact") ) )
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/incharline.p
+++ b/base/pop/getpoploglib/auto/incharline.p
@@ -1,0 +1,43 @@
+;;; Summary: character repeater to line repeater
+
+/**************************************************************************\
+Contributor                 Steve Knight
+Date                        20 Oct 91
+Description
+    Convert a character repeater to a line repeater.
+\**************************************************************************/
+
+compile_mode :pop11 +strict;
+
+section;
+
+define incharline( procedure r );
+    lconstant terminator = identfn(% termin %);
+    procedure();
+        lvars count = 0;
+        repeat
+            lvars c = r();
+            if c == `\n` do
+                consstring(count);
+                quitloop
+            elseif c == termin do
+                if count == 0 then
+                    termin
+                else
+                    ;;; Poplog guarantees that all end-of-files are
+                    ;;; preceded by end-of-lines.  However, I do not wish
+                    ;;; to rely on this undocumented fact & have put this
+                    ;;; line in as protection.
+                    consstring( count );
+                    terminator -> r;
+                endif;
+                quitloop
+            else
+                c;
+                count fi_+ 1 -> count;
+            endif;
+        endrepeat;
+    endprocedure
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/is_key_in_dict.p
+++ b/base/pop/getpoploglib/auto/is_key_in_dict.p
@@ -1,0 +1,9 @@
+compile_mode :pop11 +strict;
+
+section dict => is_key_in_dict;
+
+define global constant procedure is_key_in_dict( name, dict );
+    find( name, dict, pop_undef ) and true
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/json_pprint.p
+++ b/base/pop/getpoploglib/auto/json_pprint.p
@@ -1,0 +1,1 @@
+uses json_print

--- a/base/pop/getpoploglib/auto/json_print.p
+++ b/base/pop/getpoploglib/auto/json_print.p
@@ -1,0 +1,140 @@
+compile_mode :pop11 +strict;
+
+section $-json => json_print json_pprint;
+
+define json_print_char( ch );
+    if ch == '"' or ch == `\\` then
+        cucharout( `\\` );
+        cucharout( ch );
+    elseif ch == '\n' then
+        cucharout( `\\` );
+        cucharout( `n` );
+    elseif ch == '\r' then
+        cucharout( `\\` );
+        cucharout( `r` );
+    elseif ch == '\t' then
+        cucharout( `\\` );
+        cucharout( `t` );
+    elseif ch == '\b' then
+        cucharout( `\\` );
+        cucharout( `b` );
+    elseif ch < 32 or ch > 127 then
+        cucharout( `\\` );
+        cucharout( `u` );
+        dlocal pop_pr_radix = 16;
+        pr( ch && 16:F );
+        pr( ( ch >> 4 ) && 16:F );
+        pr( ( ch >> 8 ) && 16:F );
+        pr( ( ch >> 12 ) && 16:F );
+    else
+        cucharout( ch )
+    endif
+enddefine;
+
+define json_print_string( s );
+    cucharout( '"' );
+    appdata( s, json_print_char );
+    cucharout( '"' );
+enddefine;
+
+vars
+    MAIN_SEP = ',\n',
+    ALT_SEP = '\n',
+    TAB_WIDTH = 4;
+
+define prindent( n );
+    repeat TAB_WIDTH * n times cucharout( '\s' ) endrepeat
+enddefine;
+
+define prsep( sep );
+    sys_syspr( sep and ALT_SEP or MAIN_SEP );
+enddefine;
+
+define pprjson( x, indent, sep );
+    if x.isstring or x.isword then
+        prindent( indent );
+        json_print_string( x );
+        prsep( sep )
+    elseif x.isnumber then
+        prindent( indent );
+        sys_syspr( x );
+        prsep( sep );
+    elseif x.isboolean then
+        prindent( indent );
+        sys_syspr( x and 'true' or 'false' );
+        prsep( sep )
+    elseif x == undef or x.isundef then
+        prindent( indent );
+        sys_syspr( 'null' );
+        prsep( sep )
+    elseif x.islist then
+        ;;; Array
+        prindent( indent );
+        cucharout( '[' );
+        prsep( true );
+        lvars tail;
+        for tail on x do
+            pprjson( front( tail ), indent+1, null( tail.back ) );
+        endfor;
+        prindent( indent );
+        cucharout( ']' );
+        prsep( sep );
+    elseif x.isvectorclass then
+        ;;; Array
+        prindent( indent );
+        cucharout( '[' );
+        prsep( true );
+        lvars i, n, L = datalength( x );
+        for i with_index n in_vectorclass x do
+            pprjson( i, indent+1, n == L );
+        endfor;
+        prindent( indent );
+        cucharout( ']' );
+        prsep( sep );
+    elseif x.isdict then
+        ;;; Object
+        prindent( indent );
+        cucharout( '{' );
+        prsep( true );
+        dlvars count = 0;
+        dlvars N = dict_length( x );
+        appdict(
+            x,
+            procedure( k, v );
+                count + 1 -> count;
+                prindent( indent + 1 );
+                json_print_string( k );
+                cucharout( `:` );
+                prsep( ALT_SEP );
+                pprjson( v, indent+2, count == N );
+            endprocedure
+        );
+        prindent( indent );
+        cucharout( '}' );
+        prsep( sep );
+    else
+        prindent( indent );
+        sys_syspr( x );
+        prsep( sep );
+    endif
+enddefine;
+
+define json_pprint( x );
+    dlocal TAB_WIDTH = 4;
+    dlocal MAIN_SEP = ',\n';
+    dlocal ALT_SEP = '\n`';
+    dlocal poplinewidth = false;
+    dlocal poplinemax = false;
+    pprjson( x, 0, ALT_SEP )
+enddefine;
+
+define json_print( x );
+    dlocal TAB_WIDTH = 0;
+    dlocal MAIN_SEP = ',';
+    dlocal ALT_SEP = '';
+    dlocal poplinewidth = false;
+    dlocal poplinemax = false;
+    pprjson( x, 0, ALT_SEP )
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/json_println.p
+++ b/base/pop/getpoploglib/auto/json_println.p
@@ -1,0 +1,10 @@
+compile_mode :pop11 +strict;
+
+section;
+
+define json_println( x );
+    json_print( x );
+    nl( 1 );
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/newdict_from_assoclist.p
+++ b/base/pop/getpoploglib/auto/newdict_from_assoclist.p
@@ -1,0 +1,21 @@
+compile_mode :pop11 +strict;
+
+uses dict
+
+section dict => newdict_from_assoclist;
+
+define global constant procedure newdict_from_assoclist( list );
+    lvars keys = [];
+    lvars values = {%
+        lvars p, n = 0;
+        for p in list do
+            n fi_+ 1 -> n;
+            lvars ( k, v ) = p.dest.hd;
+            conspair( conspair( k, n ), keys ) -> keys;
+            v ;;; put values in historical order into a vector.
+        endfor
+    %};
+    newdict_internal( keys, values )
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/newdict_from_assoclist.p
+++ b/base/pop/getpoploglib/auto/newdict_from_assoclist.p
@@ -5,17 +5,7 @@ uses dict
 section dict => newdict_from_assoclist;
 
 define global constant procedure newdict_from_assoclist( list );
-    lvars keys = [];
-    lvars values = {%
-        lvars p, n = 0;
-        for p in list do
-            n fi_+ 1 -> n;
-            lvars ( k, v ) = p.dest.hd;
-            conspair( conspair( k, n ), keys ) -> keys;
-            v ;;; put values in historical order into a vector.
-        endfor
-    %};
-    newdict_internal( keys, values )
+    newdict_from_stack(#| applist( list, procedure( x ); x.dest.hd endprocedure ) |#)
 enddefine;
 
 endsection;

--- a/base/pop/getpoploglib/auto/newdict_from_twinlists.p
+++ b/base/pop/getpoploglib/auto/newdict_from_twinlists.p
@@ -1,0 +1,22 @@
+compile_mode :pop11 +strict;
+
+section dict => newdict_from_twinlists;
+
+uses dict
+
+define global constant procedure newdict_from_twinlists( keys_list, values_list );
+    lvars keys = [];
+    lvars values = {%
+        lvars n = 0;
+        until keys_list.null or values_list.null do
+            n fi_+ 1 -> n;
+            lvars k = keys_list.fast_destpair -> keys_list;
+            lvars v = values_list.fast_destpair -> values_list;
+            conspair( conspair( k, n ), keys ) -> keys;
+            v ;;; put values in historical order into a vector.
+        enduntil
+    %};
+    newdict_internal( keys, values );
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/auto/newdict_from_twinlists.p
+++ b/base/pop/getpoploglib/auto/newdict_from_twinlists.p
@@ -5,18 +5,12 @@ section dict => newdict_from_twinlists;
 uses dict
 
 define global constant procedure newdict_from_twinlists( keys_list, values_list );
-    lvars keys = [];
-    lvars values = {%
-        lvars n = 0;
-        until keys_list.null or values_list.null do
-            n fi_+ 1 -> n;
-            lvars k = keys_list.fast_destpair -> keys_list;
-            lvars v = values_list.fast_destpair -> values_list;
-            conspair( conspair( k, n ), keys ) -> keys;
-            v ;;; put values in historical order into a vector.
-        enduntil
-    %};
-    newdict_internal( keys, values );
+    newdict_from_stack(#|
+        lvars i, j;
+        for i, j in keys_list, values_list do
+            i, j
+        endfor
+    |#)
 enddefine;
 
 endsection;

--- a/base/pop/getpoploglib/auto/nulldict.p
+++ b/base/pop/getpoploglib/auto/nulldict.p
@@ -1,0 +1,7 @@
+compile_mode :pop11 +strict;
+
+section $-dict => nulldict;
+
+global constant nulldict = consdict( {}.dup );
+
+endsection;

--- a/base/pop/getpoploglib/auto/nulldict.p
+++ b/base/pop/getpoploglib/auto/nulldict.p
@@ -1,7 +1,0 @@
-compile_mode :pop11 +strict;
-
-section $-dict => nulldict;
-
-global constant nulldict = consdict( {}.dup );
-
-endsection;

--- a/base/pop/getpoploglib/auto/pop11_comp_N.p
+++ b/base/pop/getpoploglib/auto/pop11_comp_N.p
@@ -1,0 +1,52 @@
+compile_mode :pop11 +strict;
+
+section;
+
+define lconstant check_0( before );
+    lvars after = stacklength();
+    unless after == before then
+        lvars k = after fi_- before;
+        if k < 0 then
+            mishap( 'Expression consumed values, zero stack change required', [] )
+        else
+            lvars results = conslist( k );
+            mishap( 'Expression returned too many results, exactly zero required', results );
+        endif
+    endunless;
+enddefine;
+
+define lconstant check_N( before, N );
+    lvars after = stacklength();
+    lvars k = after fi_- before;
+    unless k == N then
+        if k == 0 then
+            mishap( sprintf( 'Expression generated no results but %p required', [^N] ), [] );
+        elseif k < 0 then
+            mishap( sprintf('Expression consumed values instead of returning % result(s)', [^N] ), [] )
+        else
+            lvars results = conslist( k );
+            mishap( sprintf( 'Expression returned too many results, exactly %p required', [^N] ), results );
+        endif
+    endunless;
+enddefine;
+
+lconstant procedure check_1 = check_N(% 1 %);
+
+define global constant procedure pop11_comp_N( action, N );
+    dlocal pop_new_lvar_list;
+    lvars tmpvar = sysNEW_LVAR();
+    sysCALL( "stacklength" );
+    sysPOP( tmpvar );
+    action();
+    sysPUSH( tmpvar );
+    if N == 0 then
+        sysCALLQ( check_0 )
+    elseif N == 1 then
+        sysCALLQ( check_1 );
+    else
+        sysPUSHQ( N );
+        sysCALLQ( check_N );
+    endif
+enddefine;
+
+endsection;

--- a/base/pop/getpoploglib/help/allfirst
+++ b/base/pop/getpoploglib/help/allfirst
@@ -1,0 +1,19 @@
+HELP ALLFIRST                                       Steve Knight, Jan 1991
+
+    allfirst(<integer:N>, <item>) -> <item>
+
+This procedure copies the first N elements from <item>. <item> may
+be a list, string, word, or any vector type object. The result is always
+of the same type as <item>.
+
+    allfirst(3, [dog mouse elephant pig horse]) =>
+    ** [dog mouse elephant]
+
+    allfirst(2, {cat dog mouse elephant pig horse}) =>
+    ** {cat dog}
+
+
+See also:
+    HELP * ALLLAST
+    HELP * ALLBUTFIRST
+    HELP * ALLBUTLAST

--- a/base/pop/getpoploglib/help/alllast
+++ b/base/pop/getpoploglib/help/alllast
@@ -1,0 +1,19 @@
+HELP ALLLAST                                        Steve Knight, Jan 1991
+
+    alllast(<integer:N>, <item>) -> <item>
+
+This procedure copies the last N elements from <item>. <item> may
+be a list, string, word, or any vector type object. The result is always
+of the same type as <item>.
+
+    alllast(3, [dog mouse elephant pig horse]) =>
+    ** [elephant pig horse]
+
+    alllast(2, {cat dog mouse elephant pig horse}) =>
+    ** {pig horse}
+
+
+See also:
+    HELP * ALLFIRST
+    HELP * ALLBUTFIRST
+    HELP * ALLBUTLAST

--- a/base/pop/getpoploglib/help/dict
+++ b/base/pop/getpoploglib/help/dict
@@ -6,6 +6,12 @@ HELP DICT                                         Stephen Leach Sep 2021
 <<<<<<<<<<<<<<<<<<<<<                             >>>>>>>>>>>>>>>>>>>>>>
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
+Dicts are specialised tuples that map from names (or keys) to values. They are 
+intended to represent ad hoc records with a fixed set of fields, where each 
+field is associated with a word. Like records, they cannot have new fields
+added after they are created (inextensible), can have the fields updated
+(updateable), and do not have defaults.
+
 --------------
 1  Recognisers
 --------------
@@ -18,9 +24,20 @@ isdict(item) -> bool
         Returns true if item is a dict, false otherwise.
 
 
+is_key_in_dict( name, dict ) -> bool
+        Return true if the word -name- is valid key of the dict.
+
+
 ---------------
 2  Constructors
 ---------------
+
+newdict_from_stack( key1, value1, ..., N ) -> newdict
+        Creates a newdict object based a counted sequence of interleaved 
+        key/value items on the stack. e.g.
+
+                newdict_from_stack(#| "left", -1, "ahead", 0, "right", 1 |#)
+
 
 newdict_from_assoclist(assoc_list) -> dict
         This constructs a dict from an assoc-list i.e. a list of key/values
@@ -45,6 +62,11 @@ newdict_from_twinlists(keys_list, values_list) -> dict
 ------------
 3  Accessors
 ------------
+
+dict_dest( dict ) -> key1, value1, ...., keyN, valueN, N )
+        This returns a counted, interleaved sequence of key/value items.
+        N is always an even integer.
+
 
 dict_destkeys( dict ) -> ( key1, key2, ..., keyN, N )
         This returns all the keys of a dict on the stack and a count of
@@ -79,6 +101,9 @@ appdict(dict, procedure )
         for each key/value association in dict.
 
 
+dict_copy( dict ) -> newdict
+        Creates a copy of an existing dict.
+
 dict_key -> key
         Constant holding key structure for dict
 
@@ -88,15 +113,7 @@ dict_length(dict) -> N
 
 
 nulldict -> dict
-        An instance of an empty dict object
-
-
-partapply_dict(procedure, dict) -> closure
-        Returns a closure with named frozval-slots. See HELP * PARTAPPLY_DICT.
-
-partapply_override(closure, list|dict) -> closure
-        Copies a closure and updates the frozvals from the list or dict.
-        See HELP * PARTAPPLY_OVERRIDE.
+        An instance of an empty dict object. N.B. ${} will return -nulldict-.
 
 
 --- Copyright (c) GetPoplog Sep 2021 -------------------------------------------

--- a/base/pop/getpoploglib/help/dict
+++ b/base/pop/getpoploglib/help/dict
@@ -1,0 +1,102 @@
+HELP DICT                                         Stephen Leach Sep 2021
+
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<<<                             >>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<<<           DICTS             >>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<<<                             >>>>>>>>>>>>>>>>>>>>>>
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+--------------
+1  Recognisers
+--------------
+
+is_null_dict(dict) -> bool
+        Returns true if dict is empty, false otherwise.
+
+
+isdict(item) -> bool
+        Returns true if item is a dict, false otherwise.
+
+
+---------------
+2  Constructors
+---------------
+
+newdict_from_assoclist(assoc_list) -> dict
+        This constructs a dict from an assoc-list i.e. a list of key/values
+        which are themselves a list of length 2 (or more). e.g.
+
+                newdict_from_assoclist([[a 1] [b 2]])
+
+        will return a dict that maps the word "a" to 1 and "b" to 2.
+
+
+newdict_from_twinlists(keys_list, values_list) -> dict
+        This constructs a dict from two lists, being a list of keys and
+        a parallel list of values. The lists are not required to be of equal
+        length, the first N items are taken when N is the lesser of the
+        two lengths. e.g.
+
+                newdict_from_twinlists([a b], [1 2])
+
+        will return a dict that maps the word "a" to 1 and "b" to 2.
+
+
+------------
+3  Accessors
+------------
+
+dict_destkeys( dict ) -> ( key1, key2, ..., keyN, N )
+        This returns all the keys of a dict on the stack and a count of
+        the keys. The keys will be sorted in lexicographical order.
+
+
+dist_destvalues( dict ) -> ( value1, value2, ..., valueN, N )
+        This returns all the values of a dict on the stack and a count of
+        the values returned. The values are returned in the same order as
+        the keys.
+
+
+dict( key ) -> value
+value -> dict(key)
+subscrdict(key, dict) -> value
+value -> subscrdict(key, dict)
+        This returns or updates the value associated with the key in the
+        dict. subscrdict is the class_apply of the dict_key. The key must
+        be a word.
+
+
+----------------
+4  Miscellaneous
+----------------
+
+appdict(dict, procedure )
+        Applies the  procedure  p  to  each  entry  in  the  dict.  The
+        procedure p is applied as:
+
+            p(key, value)
+
+        for each key/value association in dict.
+
+
+dict_key -> key
+        Constant holding key structure for dict
+
+
+dict_length(dict) -> N
+        Returns the number N of key/values pairs in dict.
+
+
+nulldict -> dict
+        An instance of an empty dict object
+
+
+partapply_dict(procedure, dict) -> closure
+        Returns a closure with named frozval-slots. See HELP * PARTAPPLY_DICT.
+
+partapply_override(closure, list|dict) -> closure
+        Copies a closure and updates the frozvals from the list or dict.
+        See HELP * PARTAPPLY_OVERRIDE.
+
+
+--- Copyright (c) GetPoplog Sep 2021 -------------------------------------------

--- a/base/pop/getpoploglib/help/discinline
+++ b/base/pop/getpoploglib/help/discinline
@@ -1,0 +1,13 @@
+HELP DISCINLINE                        Steve Knight, March 1990
+
+    discinline( filename ) -> line repeater;
+
+This procedure is roughly equivalent in functionality (but faster) to
+    discin <> incharline
+in that it accepts a filename, as a string, and returns a line repeater.  The
+line repeater is a procedure that returns the next line of the file each time
+it is called.  When it is exhausted it returns termin.
+
+-discinline- works by opening the file as a line oriented device.  Therefore
+it is not appropriate to supply it with an already opened device, as you may
+do with discin.

--- a/base/pop/getpoploglib/help/incharline
+++ b/base/pop/getpoploglib/help/incharline
@@ -1,0 +1,8 @@
+-----------------------------------------------------------------------------
+-- help incharline             Fri Apr 11, 1986        Steve Knight x 2366 --
+-----------------------------------------------------------------------------
+
+incharline(character repeater) -> line repeater
+
+This procedure accepts a character repeater and returns a string repeater.
+Each string is a "line" of the input.

--- a/base/pop/getpoploglib/lib/dict.p
+++ b/base/pop/getpoploglib/lib/dict.p
@@ -1,0 +1,214 @@
+compile_mode :pop11 +strict;
+
+section $-dict =>
+    dict_key isdict dict_length
+    subscr_dict appdict is_null_dict;
+
+#_IF not( isdefined( "dict_key" ) )
+
+constant ejection_threshold = 1024;
+
+define constant procedure clear_half( prop );
+    lvars clear_these = (
+        [%
+            fast_appproperty(
+                prop,
+                procedure( k, v );
+                    if random(1.0) < 0.5 then k endif
+                endprocedure
+            )
+        %]
+    );
+    lvars k;
+    for k in clear_these do
+        fast_kill_prop_entry( k, prop ) -> _;
+    endfor;
+enddefine;
+
+;;; This table is used to ensure keysets are not usually duplicated.
+constant procedure dict_table =
+    newanyproperty(
+        [], 8, 1, 8,
+        syshash, nonop =, "tmpval",
+        false,
+        procedure( key, prop );
+            ;;; Have we grown too big?
+            if datalength( prop ) > ejection_threshold then
+                clear_half( prop )
+            endif;
+            key ->> prop( key );
+        endprocedure
+    );
+
+global constant dict_key = conskey( "dict", [ full full ] );
+global constant procedure isdict = dict_key.class_recognise;
+
+constant procedure destdict = dict_key.class_dest;
+constant procedure consdict = dict_key.class_cons;
+
+;;; Not exported but retained for autoloading.
+constant procedure dict_keys = class_access( 1, dict_key );
+"dict_keys" -> dict_keys.pdprops;
+
+;;; Not exported but retained for autoloading.
+constant procedure dict_values = class_access( 2, dict_key );
+"dict_values" -> dict_values.pdprops;
+
+define global constant procedure dict_length( dict );
+    dict.dict_values.datalength
+enddefine;
+
+define lconstant find( w, dict );
+    lvars lo = 1;
+    lvars hi = dict.dict_values.datalength;
+    repeat
+        if lo < hi then
+            lvars mid = ( lo fi_+ hi ) fi_>> 1;
+            lvars midkey = subscrv( mid, dict.dict_keys );
+            lvars cmp = alphabefore( w, midkey );
+            if cmp then
+                if cmp == 1 then
+                    return( mid )
+                else
+                    mid fi_- 1 -> hi;
+                endif
+            else
+                mid fi_+ 1 -> lo;
+            endif
+        elseif lo == hi and w == subscrv( lo, dict.dict_keys ) then
+            return( hi )
+        else
+            mishap( 'Trying to index dict with invalid key', [ ^w ] )
+        endif
+    endrepeat
+enddefine;
+
+define global constant procedure subscr_dict( w, dict );
+    subscrv( find( w, dict ), dict.dict_values )
+enddefine;
+
+define updaterof subscr_dict( item, w, dict );
+    item -> subscrv( find( w, dict ), dict.dict_values )
+enddefine;
+
+subscr_dict -> class_apply( dict_key );
+
+define global constant procedure appdict( dict, procedure p );
+    lvars i, n = dict.dict_length;
+    for i from 1 to n do
+        p(
+            fast_subscrv( i, dict.dict_keys ),
+            fast_subscrv( i, dict.dict_values )
+        )
+    endfor;
+enddefine;
+
+define global constant procedure is_null_dict( dict );
+    dict.dict_values.datalength == 0
+enddefine;
+
+define prdict( dict );
+    pr( '${' );
+    unless dict.is_null_dict do pr( ' ' ) endunless;
+    dlvars first = true;
+    appdict(
+        dict,
+        procedure( k, v );
+            unless first then
+                pr( ', ' )
+            endunless;
+            pr( k );
+            pr( '=' );
+            pr( v );
+            false -> first;
+        endprocedure
+    );
+    unless dict.is_null_dict do pr( ' ' ) endunless;
+    pr( '}' );
+enddefine;
+
+prdict -> class_print( dict_key );
+
+
+define lconstant procedure check_duplicates( key_index_list );
+    lvars tail;
+    for tail on key_index_list do
+        if fast_back( tail ).ispair then
+            if fast_front( fast_front( tail ) ) == fast_front( fast_front( fast_back( tail ) ) ) then
+                mishap( 'Trying to construct dict with non-unique key', [% front(front(tail)) %] )
+            endif
+        endif
+    endfor;
+enddefine;
+
+;;;
+;;; This is a helper function for building dict objects. It takes a list
+;;; of unsorted pairs (key, position) and a vector of values and
+;;; _takes ownership of these_ i.e. no other references to these parameters
+;;; are usable after this function has run. This allows the values vector to
+;;; be sorted and the list of pairs to be returned to the heap.
+;;;
+;;; newdict_internal<T>: [ pair< word, int > ] * { T } -> dict< T >
+;;;
+define constant newdict_internal( key_index_list, values_vector );
+    nc_listsort(
+        key_index_list,
+        procedure( x, y ); alphabefore( x.front, y.front ) endprocedure
+    ) -> key_index_list;
+    check_duplicates( key_index_list );
+    lvars sorted_keys_vector = {% applist( key_index_list, front ) %};
+    lvars sorted_values_vector = fill(
+        lblock
+            lvars p;
+            for p in key_index_list do
+                subscrv( p.back, values_vector )
+            endfor
+        endlblock,
+        values_vector      ;;; !! reusing this vector !!
+    );
+    ;;; Now we can free up the working store.
+    while key_index_list.ispair do
+        ( key_index_list.sys_grbg_destpair -> key_index_list ).sys_grbg_destpair -> _ -> _;
+    endwhile;
+    ;;; And deliver the result.
+    consdict( sorted_keys_vector.dict_table, sorted_values_vector )
+enddefine;
+
+;;; This is a non-exported helper function for writing syntax words.
+define compile_newdict_to( closing_keyword ) -> actual_closer;
+    dlocal pop_new_lvar_list;
+    lvars keys = [];
+    lvars n = 0;
+    lvars tmpvars = {%
+        until pop11_try_nextreaditem( closing_keyword ) ->> actual_closer do
+            while pop11_try_nextreaditem( "," ) do endwhile;
+            n + 1 -> n;
+            lvars k = readitem();                    ;;; TODO: must be a word
+            unless k.isword do
+                mishap( 'Expected word as dict key', [^k] )
+            endunless;
+            conspair( k, n ) :: keys -> keys;
+            pop11_need_nextreaditem( "=" ) -> _;
+            dlvars tmpvar = sysNEW_LVAR();
+            pop11_comp_N( procedure(); pop11_comp_expr(); sysPOP(tmpvar) endprocedure, 0 );
+            tmpvar
+        enduntil;
+    %};
+    nc_listsort(
+        keys,
+        procedure( x, y ); alphabefore( x.front, y.front ) endprocedure
+    ) -> keys;
+    check_duplicates( keys );
+    sysPUSHQ( {% applist( keys, front ) %} );
+    lvars p;
+    for p in keys do
+        sysPUSH( subscrv( p.back, tmpvars ) )
+    endfor;
+    sysPUSHQ( tmpvars.datalength );
+    sysCALL( "consvector" );
+    sysCALLQ( consdict );
+enddefine;
+
+#_ENDIF
+
+endsection;

--- a/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
+++ b/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
@@ -47,8 +47,10 @@ define getpoplog_run_subcommand();
             valof( w )( parse_args( args ) )
         else
             dlocal cucharout = cucharerr;
-            pr( 'Unknown poplog subcommand: ' );
-            npr( subcmd );
+            pr( 'Unexpected arguments: ' );
+            pr( subcmd );
+            applist( args, procedure(a); pr( space ); pr( a ) endprocedure );
+            pr( newline );
             false -> pop_exit_ok;
             sysexit();
         endif

--- a/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
+++ b/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
@@ -47,7 +47,7 @@ define getpoplog_run_subcommand();
             valof( w )( parse_args( args ) )
         else
             dlocal cucharout = cucharerr;
-            pr( 'Cannot autoload a subcommand with this name: ' );
+            pr( 'Cannot autoload a subcommand with this name and arguments: ' );
             pr( subcmd );
             applist( args, procedure(a); pr( space ); pr( a ) endprocedure );
             pr( newline );

--- a/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
+++ b/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
@@ -47,10 +47,8 @@ define getpoplog_run_subcommand();
             valof( w )( parse_args( args ) )
         else
             dlocal cucharout = cucharerr;
-            pr( 'Cannot autoload a subcommand with this name and arguments: ' );
-            pr( subcmd );
-            applist( args, procedure(a); pr( space ); pr( a ) endprocedure );
-            pr( newline );
+            pr( 'Cannot autoload a subcommand with this name: ' );
+            npr( subcmd );
             false -> pop_exit_ok;
             sysexit();
         endif

--- a/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
+++ b/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
@@ -1,0 +1,58 @@
+compile_mode :pop11 +strict;
+
+section;
+
+uses getpoplog;
+
+;;; Given command line options of the form
+;;;     ['--option1' '--option2=value' 'nonoption1' 'nonoption2']
+;;; returns a dict and list
+;;;     ${option1=true, option2=value}, [^nonoption1 ^nonoption2]
+define lconstant parse_args( args );
+    lvars keys = [];
+    lvars values = [];
+    lvars others = [%
+        lvars arg;
+        for arg in args do
+            if isstartstring( '--', arg ) then
+                lvars n = locchar( `=`, 1, arg );
+                if n then
+                    lvars k = consword( substring( 3, n - 3, arg ) );
+                    lvars v = substring( n + 1, datalength( arg ) - n, arg );
+                    conspair( k, keys ) -> keys;
+                    conspair( v, values ) -> values;
+                else
+                    lvars k = consword( substring( 3, datalength( arg ) - 2, arg ) );
+                    conspair( k, keys ) -> keys;
+                    conspair( true, values ) -> values;
+                endif
+            else
+                arg
+            endif 
+        endfor;
+    %];
+    return( newdict_from_twinlists(keys, values), others )
+enddefine;
+
+define getpoplog_run_subcommand();
+    if poparglist.null then
+        dlocal cucharout = cucharerr;
+        npr( 'Missing options for poplog command' );
+        sysexit();
+    else
+        lvars (subcmd, args) = poparglist.dest;
+        lvars w = consword( 'getpoplog_subcommand_' <> subcmd );
+        if sys_autoload( w ) then
+            valof( w )( parse_args( args ) )
+        else
+            dlocal cucharout = cucharerr;
+            pr( 'Unknown poplog subcommand: ' );
+            npr( subcmd );
+            sysexit();
+        endif
+    endif
+enddefine;
+
+getpoplog_run_subcommand();
+
+endsection;

--- a/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
+++ b/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
@@ -38,6 +38,7 @@ define getpoplog_run_subcommand();
     if poparglist.null then
         dlocal cucharout = cucharerr;
         npr( 'Missing options for poplog command' );
+        false -> pop_exit_ok;
         sysexit();
     else
         lvars (subcmd, args) = poparglist.dest;
@@ -48,6 +49,7 @@ define getpoplog_run_subcommand();
             dlocal cucharout = cucharerr;
             pr( 'Unknown poplog subcommand: ' );
             npr( subcmd );
+            false -> pop_exit_ok;
             sysexit();
         endif
     endif

--- a/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
+++ b/base/pop/getpoploglib/lib/getpoplog_run_subcommand.p
@@ -37,7 +37,7 @@ enddefine;
 define getpoplog_run_subcommand();
     if poparglist.null then
         dlocal cucharout = cucharerr;
-        npr( 'Missing options for poplog command' );
+        npr( 'Expected name of subcommand but none was given' );
         false -> pop_exit_ok;
         sysexit();
     else
@@ -47,7 +47,7 @@ define getpoplog_run_subcommand();
             valof( w )( parse_args( args ) )
         else
             dlocal cucharout = cucharerr;
-            pr( 'Unexpected arguments: ' );
+            pr( 'Cannot autoload a subcommand with this name: ' );
             pr( subcmd );
             applist( args, procedure(a); pr( space ); pr( a ) endprocedure );
             pr( newline );

--- a/base/pop/getpoploglib/other/findhelp.schema.json
+++ b/base/pop/getpoploglib/other/findhelp.schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://github.com/GetPoplog/findhelp.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FindHelp",
+  "type": "object",
+  "properties": {
+    "popversion": {
+      "description": "A string describing the version of Poplog.",
+      "type": "string"
+    },
+    "documentation": {
+      "description": "Matching documentation.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "quality": {
+            "description": "A number from 0 to 1.0 indicating the match quality, with 1 being a perfect match.",
+            "type": "number"
+          },
+          "category": {
+            "description": "The category of documentation, reflecting the level formality and technical detail.",
+            "type": "string",
+            "enum": [ "help", "teach", "doc", "ref" ]
+          },
+          "title": {
+            "description": "The title of the resource.",
+            "type": "string"
+          },
+          "summary": {
+            "description": "An optional summary of the resource, which may be null.",
+            "type": ["string", "null"]
+          },
+          "path": {
+            "description": "File path of the resource.",
+            "type": "string"
+          },
+          "from": {
+            "description": "Line number where the description starts (1-indexed), which may be null.",
+            "type": ["integer", "null"]
+          },
+          "to": {
+            "description": "Last line number of the description, which may be null.",
+            "type": ["integer", "null"]
+          }
+        },
+        "required": ["quality", "title", "summary", "path", "from", "to", "category"],
+        "additionalProperties": false
+      }
+    },
+    "required": ["popversion", "documentation"],
+    "additionalProperties": false
+  }
+}

--- a/base/pop/lib/lib/getpoplog.p
+++ b/base/pop/lib/lib/getpoplog.p
@@ -3,6 +3,6 @@
 ;;;     - section independent
 ;;;     - safe against multiple reloads
 
-extend_searchlist( '$usepop/pop/getpoploglibs/auto', popautolist ) -> popautolist;
-extend_searchlist( '$usepop/pop/getpoploglibs/lib', popliblist ) -> popliblist;
-extend_searchlist( '$usepop/pop/getpoploglibs/help', vedhelplist ) -> vedhelplist;
+extend_searchlist( '$usepop/pop/getpoploglib/auto', popautolist ) -> popautolist;
+extend_searchlist( '$usepop/pop/getpoploglib/lib', popuseslist ) -> popuseslist;
+extend_searchlist( '$usepop/pop/getpoploglib/help', vedhelplist ) -> vedhelplist;

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -933,7 +933,7 @@ cat << \****
             execvp( shell_path, deque_as_array( argd ) );
         }
     } else if ( strchr( arg0, '=' ) != NULL ) {
-        //  If there is an '=' sign in the argument it is an environment variable.
+        // If there is an '=' sign in the argument it is an environment variable.
         vector_push( envv, arg0 );
         deque_pop_front( argd );
         return processArgs( argd, base, flags, envv );
@@ -945,8 +945,10 @@ cat << \****
         p = stpcpy( p, subpath );
         deque_push_front( argd, path );
         deque_push_front( argd, "pop11" );
+        // If execvp is successful, pop11 will responsible for returning the correct error code. 
         execvp( "pop11", deque_as_array( argd ) );
     }
+    // We only reach here if the execvp fails, which would be very unusual.
     perror( NULL );
     return EXIT_FAILURE;
 }

--- a/makePoplogCommander.sh
+++ b/makePoplogCommander.sh
@@ -938,12 +938,14 @@ cat << \****
         deque_pop_front( argd );
         return processArgs( argd, base, flags, envv );
     } else {
-        fprintf( stderr, "Unexpected arguments:" );
-        for ( int i = 0; i < deque_length( argd ); i++ ) {
-            fprintf( stderr, " %s", (char *)deque_get( argd, i ) );
-        }
-        fprintf( stderr, "\n" );
-        return EXIT_FAILURE;
+        setUpEnvironment( base, flags, envv );
+        char * subpath = "/pop/getpoploglib/lib/getpoplog_run_subcommand.p";
+        char * path = safe_malloc( strlen( subpath ) + strlen( base ) + 1 );
+        char * p = stpcpy( path, base );
+        p = stpcpy( p, subpath );
+        deque_push_front( argd, path );
+        deque_push_front( argd, "pop11" );
+        execvp( "pop11", deque_as_array( argd ) );
     }
     perror( NULL );
     return EXIT_FAILURE;

--- a/systests/test_poplog_commander.py
+++ b/systests/test_poplog_commander.py
@@ -100,13 +100,13 @@ class TestVariables:
     def test_error_message_on_invalid_var_spec(self):
         completed_process = run_poplog_commander(["FOO", "exec", "echo", "hello"])
         assert completed_process.returncode == 1
-        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name: FOO exec echo hello"
+        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name and arguments: FOO exec echo hello"
 
 
     def test_error_message_on_command(self):
         completed_process = run_poplog_commander(["asdf"])
         assert completed_process.returncode == 1
-        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name: asdf"
+        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name and arguments: asdf"
 
 
 class TestBuilds:

--- a/systests/test_poplog_commander.py
+++ b/systests/test_poplog_commander.py
@@ -100,13 +100,13 @@ class TestVariables:
     def test_error_message_on_invalid_var_spec(self):
         completed_process = run_poplog_commander(["FOO", "exec", "echo", "hello"])
         assert completed_process.returncode == 1
-        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name and arguments: FOO exec echo hello"
+        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name: FOO"
 
 
     def test_error_message_on_command(self):
         completed_process = run_poplog_commander(["asdf"])
         assert completed_process.returncode == 1
-        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name and arguments: asdf"
+        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name: asdf"
 
 
 class TestBuilds:

--- a/systests/test_poplog_commander.py
+++ b/systests/test_poplog_commander.py
@@ -100,13 +100,13 @@ class TestVariables:
     def test_error_message_on_invalid_var_spec(self):
         completed_process = run_poplog_commander(["FOO", "exec", "echo", "hello"])
         assert completed_process.returncode == 1
-        assert completed_process.stderr.decode('utf-8').strip() == "Unexpected arguments: FOO exec echo hello"
+        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name: FOO exec echo hello"
 
 
     def test_error_message_on_command(self):
         completed_process = run_poplog_commander(["asdf"])
         assert completed_process.returncode == 1
-        assert completed_process.stderr.decode('utf-8').strip() == "Unexpected arguments: asdf"
+        assert completed_process.stderr.decode('utf-8').strip() == "Cannot autoload a subcommand with this name: asdf"
 
 
 class TestBuilds:


### PR DESCRIPTION
This change makes it possible to extend the poplog-command tool using autoloadable Pop-11 files, provides a subcommand extension that can interrogate the file-based documentation using the internal library functions, and to list the results as JSON. See #130.

There are several parts to this PR:
 - Some pop-11 functions for providing the search functionality and JSON translation; these are added to the `$usepop/pop/getpoploglib/` folder.
 - A modification of the `poplog` command tool so that new subcommands can be added.
 - A new `findhelp` subcommand.

## Notes
1. The pop-11 support code includes an implementation of named-records, which I have called "dict"s in deliberate imitation of Python's dicts. I regard this implementation as the first version of an important missing feature. It also includes implementations of `discinline` and `incharline` that are imports from the GOSPL library. Over time I want to integrate all of GOSPL into GetPoplog.
2. All the extensions that are specific to the GetPoplog distribution are placed in the `getpoploglib/` folder. This folder is only linked into Poplog's search path if a programmer includes `uses getpoplog` in their project.
3. The `poplog` command tool is a C-program that is generated at build-time. At the moment it is effectively a template that is implemented as a Bash script. Fortunately this change was uncomplicated. As the script gets more complicated we should probably move the generation to another tool. Python is the GetPoplog scripting tool of choice.
 
 