### PR TITLE
Fix typo in the definition of the pop_ved environment variable, closing #132

### DIFF
--- a/makePopEnv.sh
+++ b/makePopEnv.sh
@@ -15,7 +15,7 @@ pop_pop11="-$popsavelib/startup.psv"; export pop_pop11
 pop_prolog="$pop_pop11 -$popsavelib/prolog.psv"; export pop_prolog
 pop_clisp="$pop_pop11 -$popsavelib/clisp.psv"; export pop_clisp
 pop_pml="$pop_pop11 +$popsavelib/pml.psv"; export pop_pml
-pop_ved="$pop_po11 :sysinitcomp();ved"; export pop_ved
+pop_ved="$pop_pop11 :sysinitcomp();ved"; export pop_ved
 ****
 if [[ "$withXved" = "true" ]]; then
 cat >> "$popenv" <<\****


### PR DESCRIPTION
This corrects a long-standing minor error that affected the `poplog` command tool, so that the `ved` command could not be invoked without a mishap.